### PR TITLE
fix: coerce string inputs for tags and related (#1)

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -59,6 +59,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -2405,6 +2406,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3151,6 +3153,7 @@
       "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
       "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -3623,6 +3626,7 @@
       "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.5.tgz",
       "integrity": "sha512-3qq+FUBtlTHhtYxbxheZgY8NIFnkkC/MR8u5TTsr7YZ3wixryQ3cCwn3iZbg8p8B88iDBBAYSfZDS75t8MN7Vg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=16.9.0"
       }
@@ -3944,6 +3948,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -6061,6 +6066,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -6297,6 +6303,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -1,7 +1,8 @@
 /**
- * Unit tests for MCP tool handlers.
- * We test the NoteStore + SearchIndex integration directly (same logic the MCP tools use)
+ * Unit tests for MCP tool logic and utilities.
+ * Integration tests use NoteStore + SearchIndex directly (same logic the MCP tools use)
  * rather than spinning up a full MCP server, which would require stdio transport plumbing.
+ * Pure utility tests (e.g. coerceStringArray) are also included here.
  */
 
 import fs from 'fs/promises';
@@ -177,6 +178,39 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
     const results = searchIndex.search('xyzzy123');
     expect(results).toHaveLength(1);
     expect(results[0].slug).toBe('alpha-note');
+  });
+
+  describe('tag/related string coercion — integration', () => {
+    test('create_note stores tags passed as a comma-separated string', async () => {
+      const coerced = coerceStringArray('react, hooks, typescript');
+      const note = await noteStore.upsert({
+        title: 'Coerce Test',
+        content: 'body',
+        tags: coerced,
+      });
+      expect(note.frontmatter.tags).toEqual(['react', 'hooks', 'typescript']);
+    });
+
+    test('create_note stores tags passed as a JSON-encoded string array', async () => {
+      const coerced = coerceStringArray('["react","hooks"]');
+      const note = await noteStore.upsert({
+        title: 'Coerce JSON Test',
+        content: 'body',
+        tags: coerced,
+      });
+      expect(note.frontmatter.tags).toEqual(['react', 'hooks']);
+    });
+
+    test('create_note stores related passed as a comma-separated string', async () => {
+      await noteStore.upsert({ slug: 'other-note', title: 'Other', content: 'x' });
+      const coerced = coerceStringArray('other-note');
+      const note = await noteStore.upsert({
+        title: 'With Related',
+        content: 'body',
+        related: coerced,
+      });
+      expect(note.frontmatter.related).toEqual(['other-note']);
+    });
   });
 
   // list_notes path filter

--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -10,6 +10,7 @@ import path from 'path';
 import { NoteStore } from '../../notes/NoteStore.js';
 import { SearchIndex } from '../../search/SearchIndex.js';
 import type { NoteListItem } from '../../types.js';
+import { coerceStringArray } from '../coerce.js';
 
 async function makeTmpDir(): Promise<string> {
   return fs.mkdtemp(path.join(os.tmpdir(), 'library-mcp-test-'));
@@ -245,6 +246,32 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
         readError = e as Error;
       }
       expect(readError).not.toBeNull(); // tool would return isError: true
+    });
+  });
+
+  describe('coerceStringArray', () => {
+    test('passes through an existing array unchanged', () => {
+      expect(coerceStringArray(['tag1', 'tag2'])).toEqual(['tag1', 'tag2']);
+    });
+
+    test('parses a JSON-encoded string array', () => {
+      expect(coerceStringArray('["tag1", "tag2"]')).toEqual(['tag1', 'tag2']);
+    });
+
+    test('splits a comma-separated string into an array', () => {
+      expect(coerceStringArray('tag1, tag2, tag3')).toEqual(['tag1', 'tag2', 'tag3']);
+    });
+
+    test('wraps a single value with no commas in an array', () => {
+      expect(coerceStringArray('tag1')).toEqual(['tag1']);
+    });
+
+    test('returns undefined for undefined input', () => {
+      expect(coerceStringArray(undefined)).toBeUndefined();
+    });
+
+    test('trims whitespace from comma-separated values', () => {
+      expect(coerceStringArray('  tag1 ,  tag2  ')).toEqual(['tag1', 'tag2']);
     });
   });
 });

--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -8,6 +8,7 @@
 import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
+import { z } from 'zod';
 import { NoteStore } from '../../notes/NoteStore.js';
 import { SearchIndex } from '../../search/SearchIndex.js';
 import type { NoteListItem } from '../../types.js';
@@ -180,36 +181,28 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
     expect(results[0].slug).toBe('alpha-note');
   });
 
-  describe('tag/related string coercion — integration', () => {
-    test('create_note stores tags passed as a comma-separated string', async () => {
-      const coerced = coerceStringArray('react, hooks, typescript');
-      const note = await noteStore.upsert({
-        title: 'Coerce Test',
-        content: 'body',
-        tags: coerced,
-      });
-      expect(note.frontmatter.tags).toEqual(['react', 'hooks', 'typescript']);
+  describe('tag/related string coercion — Zod schema wiring', () => {
+    // Construct the same schema used in create_note and update_note
+    const tagsSchema = z.preprocess(coerceStringArray, z.array(z.string()).optional());
+
+    test('schema coerces comma-separated string to array', () => {
+      expect(tagsSchema.parse('react, hooks, typescript')).toEqual(['react', 'hooks', 'typescript']);
     });
 
-    test('create_note stores tags passed as a JSON-encoded string array', async () => {
-      const coerced = coerceStringArray('["react","hooks"]');
-      const note = await noteStore.upsert({
-        title: 'Coerce JSON Test',
-        content: 'body',
-        tags: coerced,
-      });
-      expect(note.frontmatter.tags).toEqual(['react', 'hooks']);
+    test('schema coerces JSON-encoded string array to array', () => {
+      expect(tagsSchema.parse('["react","hooks"]')).toEqual(['react', 'hooks']);
     });
 
-    test('create_note stores related passed as a comma-separated string', async () => {
-      await noteStore.upsert({ slug: 'other-note', title: 'Other', content: 'x' });
-      const coerced = coerceStringArray('other-note');
-      const note = await noteStore.upsert({
-        title: 'With Related',
-        content: 'body',
-        related: coerced,
-      });
-      expect(note.frontmatter.related).toEqual(['other-note']);
+    test('schema passes through an actual array unchanged', () => {
+      expect(tagsSchema.parse(['react', 'hooks'])).toEqual(['react', 'hooks']);
+    });
+
+    test('schema accepts undefined', () => {
+      expect(tagsSchema.parse(undefined)).toBeUndefined();
+    });
+
+    test('schema coerces single bare string to single-element array', () => {
+      expect(tagsSchema.parse('typescript')).toEqual(['typescript']);
     });
   });
 

--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -270,6 +270,10 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
       expect(coerceStringArray(undefined)).toBeUndefined();
     });
 
+    test('returns undefined for null input', () => {
+      expect(coerceStringArray(null)).toBeUndefined();
+    });
+
     test('trims whitespace from comma-separated values', () => {
       expect(coerceStringArray('  tag1 ,  tag2  ')).toEqual(['tag1', 'tag2']);
     });

--- a/server/src/mcp/coerce.ts
+++ b/server/src/mcp/coerce.ts
@@ -6,6 +6,7 @@
  * - A comma-separated string: 'tag1, tag2'
  * - A single bare string: 'tag1'
  * - An already-correct array: ['tag1', 'tag2']
+ * - A JSON-encoded non-array (e.g. '42', '{"a":1}'): treated as a plain string, comma-split
  */
 export function coerceStringArray(val: unknown): string[] | undefined {
   if (val === undefined || val === null) return undefined;

--- a/server/src/mcp/coerce.ts
+++ b/server/src/mcp/coerce.ts
@@ -1,0 +1,25 @@
+/**
+ * Coerces an unknown input to string[] | undefined.
+ *
+ * Handles the common case where LLM clients pass tags/related as:
+ * - A JSON-encoded array string: '["tag1","tag2"]'
+ * - A comma-separated string: 'tag1, tag2'
+ * - A single bare string: 'tag1'
+ * - An already-correct array: ['tag1', 'tag2']
+ */
+export function coerceStringArray(val: unknown): string[] | undefined {
+  if (val === undefined || val === null) return undefined;
+  if (Array.isArray(val)) return val as string[];
+  if (typeof val === 'string') {
+    const trimmed = val.trim();
+    if (trimmed === '') return undefined;
+    try {
+      const parsed = JSON.parse(trimmed);
+      if (Array.isArray(parsed)) return parsed.map(String);
+    } catch {
+      // not JSON — fall through to comma split
+    }
+    return trimmed.split(',').map((s) => s.trim()).filter(Boolean);
+  }
+  return undefined;
+}

--- a/server/src/mcp/coerce.ts
+++ b/server/src/mcp/coerce.ts
@@ -9,7 +9,7 @@
  */
 export function coerceStringArray(val: unknown): string[] | undefined {
   if (val === undefined || val === null) return undefined;
-  if (Array.isArray(val)) return val as string[];
+  if (Array.isArray(val)) return val.map(String);
   if (typeof val === 'string') {
     const trimmed = val.trim();
     if (trimmed === '') return undefined;

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -4,6 +4,7 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { z } from 'zod';
 import { NoteStore } from '../notes/NoteStore.js';
 import { SearchIndex } from '../search/SearchIndex.js';
+import { coerceStringArray } from './coerce.js';
 
 function isValidSlug(slug: string): boolean {
   return !slug.includes('..') && !slug.startsWith('/');
@@ -83,8 +84,8 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
       title: z.string().describe('The note title'),
       content: z.string().describe('Markdown content for the note body'),
       path: z.string().optional().describe('Vault-relative path for the note slug (e.g. "projects/startup/my-note"). Defaults to inbox/<title-slug>.'),
-      tags: z.array(z.string()).optional().describe('Tags to categorize the note'),
-      related: z.array(z.string()).optional().describe('Slugs of related notes'),
+      tags: z.preprocess(coerceStringArray, z.array(z.string()).optional()).describe('Tags to categorize the note'),
+      related: z.preprocess(coerceStringArray, z.array(z.string()).optional()).describe('Slugs of related notes'),
     },
     async ({ title, content, path: notePath, tags, related }) => {
       const slug = notePath ?? ('inbox/' + NoteStore.makeSlug(title));
@@ -114,8 +115,8 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
       slug: z.string().describe('The slug of the note to update'),
       title: z.string().describe('New title for the note'),
       content: z.string().describe('New markdown content for the note body'),
-      tags: z.array(z.string()).optional().describe('Updated tags'),
-      related: z.array(z.string()).optional().describe('Updated related note slugs'),
+      tags: z.preprocess(coerceStringArray, z.array(z.string()).optional()).describe('Updated tags'),
+      related: z.preprocess(coerceStringArray, z.array(z.string()).optional()).describe('Updated related note slugs'),
     },
     async ({ slug, title, content, tags, related }) => {
       if (!isValidSlug(slug)) return slugValidationError(slug);


### PR DESCRIPTION
## Summary

Fixes #1 — LLM clients frequently pass `tags` and `related` as strings instead of arrays, causing Zod validation failures and forced retries on every affected call.

- Adds `server/src/mcp/coerce.ts` with a `coerceStringArray(val: unknown): string[] | undefined` utility that handles JSON-encoded arrays, comma-separated strings, single bare strings, and existing arrays
- Wraps `tags` and `related` in both `create_note` and `update_note` with `z.preprocess(coerceStringArray, ...)` so coercion happens at the schema layer before handlers run
- 7 unit tests for the utility + 5 schema-wiring tests using `z.preprocess` directly + null input test

## Test plan

- [ ] All 58 tests pass (`npm test` in `server/`)
- [ ] Manual: pass `tags` as `"react, hooks"` to `create_note` — should store as `["react", "hooks"]`
- [ ] Manual: pass `tags` as `'["react","hooks"]'` to `create_note` — should store as `["react", "hooks"]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)