### PR TITLE
docs: document MCP resources in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,8 +122,8 @@ MCP resources are read-only and can be enumerated by clients at startup, making 
 | Resource | Purpose |
 |---|---|
 | `vault://context` | Vault bootstrap document (`profile.md`). Read this first to orient to the vault. |
-| `notes://index` | Index of all notes — slugs, titles, tags, and dates. |
-| `note://{slug}` | Individual note content by slug (e.g. `note://projects/startup`). |
+| `notes://index` | Index of all notes with titles, tags, dates, and links to each `note://` URI. |
+| `note://{slug}` | Individual note content by slug (e.g. `note://projects/startup`). Discover slugs via `notes://index`. |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,16 @@ If `profile.md` doesn't exist, `get_vault_context` returns a clear error message
 | `update_note` | Update an existing note by slug |
 | `delete_note` | Delete a note by slug |
 
+## Resources exposed to Claude
+
+MCP resources are read-only and can be enumerated by clients at startup, making them useful for discoverability.
+
+| Resource | Purpose |
+|---|---|
+| `vault://context` | Vault bootstrap document (`profile.md`). Read this first to orient to the vault. |
+| `notes://index` | Index of all notes — slugs, titles, tags, and dates. |
+| `note://{slug}` | Individual note content by slug (e.g. `note://projects/startup`). |
+
 ## Development
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds "Resources exposed to Claude" section to README listing all three MCP resources
- Improves `notes://index` description to clarify it contains links to `note://` URIs
- Adds discoverability cross-reference to `note://{slug}` row

Closes #22

## Test Plan
- [ ] README renders correctly with new section
- [ ] All resource URIs and descriptions match server implementation