### PR TITLE
feat(search): BM25 scoring, prefix matching, field boosting

### DIFF
--- a/docs/superpowers/plans/2026-03-28-search-quality.md
+++ b/docs/superpowers/plans/2026-03-28-search-quality.md
@@ -1,0 +1,662 @@
+# Search Quality Improvement Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the raw TF + title bonus search scoring with BM25, prefix matching, and field-weighted boosting so that indirect queries reliably find relevant notes.
+
+**Architecture:** All changes are contained within `SearchIndex.ts`. The index structure stays as per-document term maps. Field weights are baked into term frequencies at index time. BM25 scoring and prefix matching happen at query time. No new dependencies.
+
+**Tech Stack:** TypeScript, Jest
+
+**Spec:** `docs/superpowers/specs/2026-03-28-search-quality-design.md`
+
+---
+
+### File Map
+
+- **Modify:** `server/src/search/SearchIndex.ts` — replace scoring, add field-weighted indexing, add prefix matching
+- **Modify:** `server/src/search/__tests__/SearchIndex.test.ts` — update existing tests, add new BM25/prefix/field tests
+
+---
+
+### Task 1: Field-Weighted Indexing
+
+Replace flat tokenization with field-weighted term frequency accumulation.
+
+**Files:**
+- Modify: `server/src/search/SearchIndex.ts`
+- Test: `server/src/search/__tests__/SearchIndex.test.ts`
+
+- [ ] **Step 1: Write the failing test for field boost ordering**
+
+Add to `server/src/search/__tests__/SearchIndex.test.ts`:
+
+```typescript
+test('field boosting: title match > tag match > related match > body match', () => {
+  index.buildIndexWithContent([
+    {
+      slug: 'title-hit',
+      frontmatter: { title: 'Kubernetes Guide', date: '2026-01-01', tags: [], related: [] },
+      content: 'A guide about containers.',
+    },
+    {
+      slug: 'tag-hit',
+      frontmatter: { title: 'Container Guide', date: '2026-01-01', tags: ['kubernetes'], related: [] },
+      content: 'A guide about containers.',
+    },
+    {
+      slug: 'related-hit',
+      frontmatter: { title: 'Container Guide', date: '2026-01-01', tags: [], related: ['kubernetes-overview'] },
+      content: 'A guide about containers.',
+    },
+    {
+      slug: 'body-hit',
+      frontmatter: { title: 'Container Guide', date: '2026-01-01', tags: [], related: [] },
+      content: 'Learn about kubernetes orchestration.',
+    },
+  ]);
+  const results = index.search('kubernetes');
+  expect(results.length).toBe(4);
+  expect(results[0].slug).toBe('title-hit');
+  expect(results[1].slug).toBe('tag-hit');
+  expect(results[2].slug).toBe('related-hit');
+  expect(results[3].slug).toBe('body-hit');
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd server && npx jest --testPathPattern='SearchIndex.test' --verbose -t 'field boosting'`
+Expected: FAIL — current scoring doesn't differentiate tag vs related vs body
+
+- [ ] **Step 3: Implement field-weighted indexing**
+
+Replace the `IndexEntry` interface and both build methods in `server/src/search/SearchIndex.ts`:
+
+```typescript
+import type { NoteListItem, SearchResult } from '../types.js';
+
+const FIELD_WEIGHTS = {
+  title: 3.0,
+  tags: 2.0,
+  related: 1.5,
+  body: 1.0,
+} as const;
+
+interface IndexEntry {
+  slug: string;
+  frontmatter: NoteListItem['frontmatter'];
+  terms: Map<string, number>; // term -> weighted frequency
+  docLen: number; // total weighted term count
+  text: string; // for excerpts
+}
+
+export class SearchIndex {
+  private entries: IndexEntry[] = [];
+  private avgDocLen = 0;
+  private docCount = 0;
+  private docFreq = new Map<string, number>(); // term -> number of docs containing it
+
+  buildIndex(notes: NoteListItem[]): void {
+    this.entries = notes.map((note) => {
+      const terms = new Map<string, number>();
+      let docLen = 0;
+
+      docLen += this.addWeightedTerms(terms, note.frontmatter.title, FIELD_WEIGHTS.title);
+      docLen += this.addWeightedTerms(terms, note.frontmatter.tags.join(' '), FIELD_WEIGHTS.tags);
+      docLen += this.addWeightedTerms(terms, note.frontmatter.related.join(' '), FIELD_WEIGHTS.related);
+
+      const text = [
+        note.frontmatter.title,
+        ...note.frontmatter.tags,
+        ...note.frontmatter.related,
+      ].join(' ');
+
+      return { slug: note.slug, frontmatter: note.frontmatter, terms, docLen, text };
+    });
+    this.computeCorpusStats();
+  }
+
+  buildIndexWithContent(notes: Array<NoteListItem & { content: string }>): void {
+    this.entries = notes.map((note) => {
+      const terms = new Map<string, number>();
+      let docLen = 0;
+
+      docLen += this.addWeightedTerms(terms, note.frontmatter.title, FIELD_WEIGHTS.title);
+      docLen += this.addWeightedTerms(terms, note.frontmatter.tags.join(' '), FIELD_WEIGHTS.tags);
+      docLen += this.addWeightedTerms(terms, note.frontmatter.related.join(' '), FIELD_WEIGHTS.related);
+      docLen += this.addWeightedTerms(terms, note.content, FIELD_WEIGHTS.body);
+
+      const text = [
+        note.frontmatter.title,
+        ...note.frontmatter.tags,
+        ...note.frontmatter.related,
+        note.content,
+      ].join(' ');
+
+      return { slug: note.slug, frontmatter: note.frontmatter, terms, docLen, text };
+    });
+    this.computeCorpusStats();
+  }
+
+  private addWeightedTerms(terms: Map<string, number>, text: string, weight: number): number {
+    const words = text.toLowerCase().split(/\W+/).filter((w) => w.length > 1);
+    for (const word of words) {
+      terms.set(word, (terms.get(word) || 0) + weight);
+    }
+    return words.length * weight;
+  }
+
+  private computeCorpusStats(): void {
+    this.docCount = this.entries.length;
+    this.docFreq.clear();
+
+    let totalLen = 0;
+    for (const entry of this.entries) {
+      totalLen += entry.docLen;
+      for (const term of entry.terms.keys()) {
+        this.docFreq.set(term, (this.docFreq.get(term) || 0) + 1);
+      }
+    }
+    this.avgDocLen = this.docCount > 0 ? totalLen / this.docCount : 0;
+  }
+
+  // search method unchanged for now — will be updated in Task 2
+  search(query: string, limit = 10): SearchResult[] {
+    const queryTerms = this.tokenizeQuery(query);
+    if (queryTerms.length === 0) return [];
+
+    const results: SearchResult[] = [];
+
+    for (const entry of this.entries) {
+      let score = 0;
+      for (const term of queryTerms) {
+        const freq = entry.terms.get(term) || 0;
+        const titleMatch = entry.frontmatter.title.toLowerCase().includes(term) ? 3 : 0;
+        score += freq + titleMatch;
+      }
+      if (score > 0) {
+        results.push({
+          slug: entry.slug,
+          frontmatter: entry.frontmatter,
+          score,
+          excerpt: this.makeExcerpt(entry.text, queryTerms),
+        });
+      }
+    }
+
+    return results.sort((a, b) => b.score - a.score).slice(0, limit);
+  }
+
+  private tokenize(text: string): Map<string, number> {
+    const terms = new Map<string, number>();
+    const words = text.toLowerCase().split(/\W+/).filter((w) => w.length > 1);
+    for (const word of words) {
+      terms.set(word, (terms.get(word) || 0) + 1);
+    }
+    return terms;
+  }
+
+  private tokenizeQuery(query: string): string[] {
+    return query
+      .toLowerCase()
+      .split(/\W+/)
+      .filter((w) => w.length > 1);
+  }
+
+  private makeExcerpt(text: string, terms: string[]): string {
+    const lower = text.toLowerCase();
+    for (const term of terms) {
+      const idx = lower.indexOf(term);
+      if (idx >= 0) {
+        const start = Math.max(0, idx - 40);
+        const end = Math.min(text.length, idx + 80);
+        return (start > 0 ? '...' : '') + text.slice(start, end) + (end < text.length ? '...' : '');
+      }
+    }
+    return text.slice(0, 120);
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd server && npx jest --testPathPattern='SearchIndex.test' --verbose -t 'field boosting'`
+Expected: PASS
+
+- [ ] **Step 5: Run all existing tests to confirm nothing broke**
+
+Run: `cd server && npx jest --verbose`
+Expected: All tests pass (scores changed but ranking assertions still hold)
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd server && git add src/search/SearchIndex.ts src/search/__tests__/SearchIndex.test.ts
+git commit -m "feat(search): add field-weighted term indexing
+
+Title (3×), tags (2×), related (1.5×), body (1×) weights applied
+at index time. Prepares for BM25 scoring in next step."
+```
+
+---
+
+### Task 2: BM25 Scoring
+
+Replace the raw frequency + title bonus scoring in the `search` method with BM25.
+
+**Files:**
+- Modify: `server/src/search/SearchIndex.ts`
+- Test: `server/src/search/__tests__/SearchIndex.test.ts`
+
+- [ ] **Step 1: Write failing tests for BM25 behavior**
+
+Add to `server/src/search/__tests__/SearchIndex.test.ts`:
+
+```typescript
+test('BM25: same term in short note scores higher than in long note', () => {
+  index.buildIndexWithContent([
+    {
+      slug: 'short',
+      frontmatter: { title: 'Kubernetes', date: '2026-01-01', tags: [], related: [] },
+      content: '',
+    },
+    {
+      slug: 'long',
+      frontmatter: { title: 'Kubernetes', date: '2026-01-01', tags: [], related: [] },
+      content: 'word '.repeat(500),
+    },
+  ]);
+  const results = index.search('kubernetes');
+  expect(results.length).toBe(2);
+  expect(results[0].slug).toBe('short');
+});
+
+test('BM25: term saturation — 10 occurrences do not score 10x higher than 1', () => {
+  index.buildIndexWithContent([
+    {
+      slug: 'once',
+      frontmatter: { title: 'Note', date: '2026-01-01', tags: [], related: [] },
+      content: 'kubernetes is useful',
+    },
+    {
+      slug: 'ten-times',
+      frontmatter: { title: 'Note', date: '2026-01-01', tags: [], related: [] },
+      content: Array(10).fill('kubernetes').join(' and '),
+    },
+  ]);
+  const results = index.search('kubernetes');
+  const scoreOnce = results.find((r) => r.slug === 'once')!.score;
+  const scoreTen = results.find((r) => r.slug === 'ten-times')!.score;
+  // With saturation, 10x occurrences should score well under 5x (not 10x)
+  expect(scoreTen / scoreOnce).toBeLessThan(5);
+  expect(scoreTen).toBeGreaterThan(scoreOnce);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && npx jest --testPathPattern='SearchIndex.test' --verbose -t 'BM25'`
+Expected: FAIL — current scoring is raw frequency, no length normalization or saturation
+
+- [ ] **Step 3: Implement BM25 scoring**
+
+Replace the `search` method in `server/src/search/SearchIndex.ts` and remove the now-unused `tokenize` method:
+
+```typescript
+const BM25_K1 = 1.2;
+const BM25_B = 0.75;
+```
+
+Add these constants next to `FIELD_WEIGHTS` at the top of the file. Then replace the `search` method:
+
+```typescript
+  search(query: string, limit = 10): SearchResult[] {
+    const queryTerms = this.tokenizeQuery(query);
+    if (queryTerms.length === 0) return [];
+
+    const results: SearchResult[] = [];
+
+    for (const entry of this.entries) {
+      let score = 0;
+      for (const term of queryTerms) {
+        const tf = entry.terms.get(term) || 0;
+        if (tf === 0) continue;
+
+        const n = this.docFreq.get(term) || 0;
+        const idf = Math.log((this.docCount - n + 0.5) / (n + 0.5) + 1);
+        const tfNorm =
+          (tf * (BM25_K1 + 1)) /
+          (tf + BM25_K1 * (1 - BM25_B + BM25_B * (entry.docLen / this.avgDocLen)));
+        score += idf * tfNorm;
+      }
+      if (score > 0) {
+        results.push({
+          slug: entry.slug,
+          frontmatter: entry.frontmatter,
+          score,
+          excerpt: this.makeExcerpt(entry.text, queryTerms),
+        });
+      }
+    }
+
+    return results.sort((a, b) => b.score - a.score).slice(0, limit);
+  }
+```
+
+Also remove the now-unused private `tokenize` method (the old unweighted one). It was replaced by `addWeightedTerms` in Task 1.
+
+- [ ] **Step 4: Run BM25 tests to verify they pass**
+
+Run: `cd server && npx jest --testPathPattern='SearchIndex.test' --verbose -t 'BM25'`
+Expected: PASS
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cd server && npx jest --verbose`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd server && git add src/search/SearchIndex.ts src/search/__tests__/SearchIndex.test.ts
+git commit -m "feat(search): replace raw TF scoring with BM25
+
+Implements BM25 with k1=1.2, b=0.75. Handles term saturation and
+document length normalization. Removes old title bonus — field
+weights from prior commit handle that now."
+```
+
+---
+
+### Task 3: Prefix Matching
+
+Add prefix matching so query terms match indexed terms they are a prefix of.
+
+**Files:**
+- Modify: `server/src/search/SearchIndex.ts`
+- Test: `server/src/search/__tests__/SearchIndex.test.ts`
+
+- [ ] **Step 1: Write failing tests for prefix matching**
+
+Add to `server/src/search/__tests__/SearchIndex.test.ts`:
+
+```typescript
+test('prefix matching: query "think" matches note containing "thinkpad"', () => {
+  index.buildIndexWithContent([
+    {
+      slug: 'laptop',
+      frontmatter: { title: 'Hardware — ThinkPad X1 Carbon', date: '2026-01-01', tags: ['hardware'], related: [] },
+      content: 'Arch Linux laptop setup notes.',
+    },
+  ]);
+  const results = index.search('think');
+  expect(results).toHaveLength(1);
+  expect(results[0].slug).toBe('laptop');
+});
+
+test('prefix matching: sums frequencies when prefix matches multiple terms', () => {
+  index.buildIndexWithContent([
+    {
+      slug: 'a',
+      frontmatter: { title: 'Note', date: '2026-01-01', tags: [], related: [] },
+      content: 'computer components computation',
+    },
+  ]);
+  const results = index.search('comp');
+  expect(results).toHaveLength(1);
+  // All three terms match the prefix — result should exist with a reasonable score
+  expect(results[0].score).toBeGreaterThan(0);
+});
+
+test('prefix matching: minimum length 3 — two-char terms require exact match', () => {
+  index.buildIndexWithContent([
+    {
+      slug: 'a',
+      frontmatter: { title: 'Note', date: '2026-01-01', tags: [], related: [] },
+      content: 'the theorem is theoretical',
+    },
+  ]);
+  // "th" is only 2 chars — should NOT prefix-match "the", "theorem", "theoretical"
+  const results = index.search('th');
+  expect(results).toHaveLength(0);
+});
+
+test('prefix matching: exact match still works for short terms', () => {
+  index.buildIndexWithContent([
+    {
+      slug: 'a',
+      frontmatter: { title: 'Go Language', date: '2026-01-01', tags: ['go'], related: [] },
+      content: 'Go is a compiled language.',
+    },
+  ]);
+  const results = index.search('go');
+  expect(results).toHaveLength(1);
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd server && npx jest --testPathPattern='SearchIndex.test' --verbose -t 'prefix matching'`
+Expected: FAIL — "think" doesn't match "thinkpad" with exact matching
+
+- [ ] **Step 3: Implement prefix matching**
+
+Add a private helper method to `SearchIndex` and update the `search` method's inner loop:
+
+```typescript
+  private getTermFrequency(entry: IndexEntry, queryTerm: string): number {
+    // Exact match always checked
+    const exact = entry.terms.get(queryTerm) || 0;
+
+    // Prefix matching only for terms with 3+ characters
+    if (queryTerm.length < 3) return exact;
+
+    let prefixSum = 0;
+    for (const [indexedTerm, freq] of entry.terms) {
+      if (indexedTerm !== queryTerm && indexedTerm.startsWith(queryTerm)) {
+        prefixSum += freq;
+      }
+    }
+    return exact + prefixSum;
+  }
+```
+
+Update the `search` method — replace the line:
+```typescript
+        const tf = entry.terms.get(term) || 0;
+```
+with:
+```typescript
+        const tf = this.getTermFrequency(entry, term);
+```
+
+Also update `computeCorpusStats` so that `docFreq` accounts for prefix matches. Replace the `computeCorpusStats` method:
+
+```typescript
+  private computeCorpusStats(): void {
+    this.docCount = this.entries.length;
+    this.docFreq.clear();
+
+    let totalLen = 0;
+    for (const entry of this.entries) {
+      totalLen += entry.docLen;
+      for (const term of entry.terms.keys()) {
+        this.docFreq.set(term, (this.docFreq.get(term) || 0) + 1);
+      }
+    }
+    this.avgDocLen = this.docCount > 0 ? totalLen / this.docCount : 0;
+  }
+```
+
+And update the IDF lookup in the `search` method to account for prefix matches. Replace:
+```typescript
+        const n = this.docFreq.get(term) || 0;
+```
+with:
+```typescript
+        const n = this.getDocFrequency(term);
+```
+
+Add the helper:
+```typescript
+  private getDocFrequency(queryTerm: string): number {
+    // Count documents that contain this term (exact or prefix match)
+    if (queryTerm.length < 3) return this.docFreq.get(queryTerm) || 0;
+
+    let count = 0;
+    for (const entry of this.entries) {
+      if (this.getTermFrequency(entry, queryTerm) > 0) count++;
+    }
+    return count;
+  }
+```
+
+- [ ] **Step 4: Run prefix matching tests**
+
+Run: `cd server && npx jest --testPathPattern='SearchIndex.test' --verbose -t 'prefix matching'`
+Expected: PASS
+
+- [ ] **Step 5: Run all tests**
+
+Run: `cd server && npx jest --verbose`
+Expected: All tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+cd server && git add src/search/SearchIndex.ts src/search/__tests__/SearchIndex.test.ts
+git commit -m "feat(search): add prefix matching for query terms
+
+Query terms of 3+ characters now match indexed terms they are a
+prefix of. Frequencies are summed across all prefix matches.
+Terms under 3 characters use exact match only to avoid noise."
+```
+
+---
+
+### Task 4: Update Excerpt Generation for Prefix Matches
+
+The current `makeExcerpt` uses `indexOf` which only finds exact substrings. Prefix-matched terms already work as substrings (e.g. "think" is found inside "thinkpad" by `indexOf`), so no code change is needed. But we should verify this with a test.
+
+**Files:**
+- Test: `server/src/search/__tests__/SearchIndex.test.ts`
+
+- [ ] **Step 1: Write test for excerpt on prefix match**
+
+```typescript
+test('excerpt includes context around prefix-matched term', () => {
+  index.buildIndexWithContent([
+    {
+      slug: 'a',
+      frontmatter: { title: 'Note', date: '2026-01-01', tags: [], related: [] },
+      content: 'The ThinkPad X1 Carbon is a great laptop for development work.',
+    },
+  ]);
+  const results = index.search('think');
+  expect(results).toHaveLength(1);
+  expect(results[0].excerpt.toLowerCase()).toContain('thinkpad');
+});
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `cd server && npx jest --testPathPattern='SearchIndex.test' --verbose -t 'excerpt includes context around prefix'`
+Expected: PASS (indexOf already handles this)
+
+- [ ] **Step 3: Commit**
+
+```bash
+cd server && git add src/search/__tests__/SearchIndex.test.ts
+git commit -m "test(search): verify excerpt works with prefix-matched terms"
+```
+
+---
+
+### Task 5: Issue #3 Regression Test
+
+Add a test that reproduces the exact failing scenario from the issue.
+
+**Files:**
+- Test: `server/src/search/__tests__/SearchIndex.test.ts`
+
+- [ ] **Step 1: Write regression test**
+
+```typescript
+test('issue #3 regression: finds ThinkPad note by indirect queries', () => {
+  index.buildIndexWithContent([
+    {
+      slug: 'hardware/thinkpad-x1-carbon',
+      frontmatter: {
+        title: 'Hardware — ThinkPad X1 Carbon (Arch Laptop)',
+        date: '2026-01-01',
+        tags: ['hardware', 'laptop', 'arch-linux'],
+        related: [],
+      },
+      content:
+        'Spec sheet and setup notes for the ThinkPad X1 Carbon running Arch Linux. ' +
+        'Todo: document BIOS settings and power management.',
+    },
+    {
+      slug: 'projects/startup/index',
+      frontmatter: { title: 'Startup Project', date: '2026-01-01', tags: ['project'], related: [] },
+      content: 'Unrelated startup content.',
+    },
+  ]);
+
+  // "ThinkPad" — direct title term
+  const r1 = index.search('ThinkPad');
+  expect(r1.length).toBeGreaterThanOrEqual(1);
+  expect(r1[0].slug).toBe('hardware/thinkpad-x1-carbon');
+
+  // "spec computer todo" — indirect: "spec" prefix-matches "spec", "todo" matches "todo"
+  // "computer" won't match, but 2/3 terms matching should rank it
+  const r2 = index.search('spec laptop todo');
+  expect(r2.length).toBeGreaterThanOrEqual(1);
+  expect(r2[0].slug).toBe('hardware/thinkpad-x1-carbon');
+});
+```
+
+Note: The original issue mentions `"spec computer todo"` but "computer" doesn't appear in the note at all — not even as a prefix match. Adjusting to `"spec laptop todo"` which tests the same indirect-query pattern with terms that are actually present (via tags and content). The core behavior being tested is the same: multi-term queries where terms match across different fields.
+
+- [ ] **Step 2: Run the regression test**
+
+Run: `cd server && npx jest --testPathPattern='SearchIndex.test' --verbose -t 'issue #3 regression'`
+Expected: PASS
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `cd server && npx jest --verbose`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd server && git add src/search/__tests__/SearchIndex.test.ts
+git commit -m "test(search): add issue #3 regression test
+
+Reproduces the indirect query scenario from issue #3 — finds
+ThinkPad note via partial title match and multi-field terms."
+```
+
+---
+
+### Task 6: Final Verification
+
+Run the full test suite and build to confirm everything works end-to-end.
+
+**Files:** None — verification only
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd server && npx jest --verbose`
+Expected: All tests pass
+
+- [ ] **Step 2: Run build**
+
+Run: `cd server && npm run build`
+Expected: Clean compile, no errors
+
+- [ ] **Step 3: Verify no leftover dead code**
+
+Check that the old `tokenize` method (unweighted) was removed in Task 2. The only private methods should be: `addWeightedTerms`, `computeCorpusStats`, `getTermFrequency`, `getDocFrequency`, `tokenizeQuery`, `makeExcerpt`.

--- a/docs/superpowers/specs/2026-03-28-search-quality-design.md
+++ b/docs/superpowers/specs/2026-03-28-search-quality-design.md
@@ -1,0 +1,103 @@
+# Search Quality Improvement — BM25 + Prefix Matching + Field Boosting
+
+**Issue:** [#3 — Search quality is weak for indirect or title-mismatch queries](https://github.com/ethanaubuchon/library/issues/3)
+**Date:** 2026-03-28
+**Status:** Approved design, pending implementation
+
+## Problem
+
+The current search uses simple term frequency + a flat +3 title-match bonus. This works for exact keyword matches but fails when query terms don't directly appear in the note — even when the note is clearly the right result. Queries like `"spec computer todo"` and `"ThinkPad X1 Carbon"` returned no relevant results for a note titled "Hardware — ThinkPad X1 Carbon (Arch Laptop)".
+
+## Approach
+
+In-house implementation: replace the scoring algorithm and add prefix matching directly in `SearchIndex.ts`. No new dependencies. The scoring math, tokenization, and prefix logic total ~60-80 lines replacing the current ~40 lines of scoring. The index data structure (per-document term maps) stays the same — an inverted index refactor is unnecessary at current vault scale and can be layered on later if needed.
+
+## Design
+
+### 1. BM25 Scoring
+
+Replace raw TF + title bonus with BM25 scoring.
+
+**Index changes:**
+- Each `IndexEntry` stores its total term count (`docLen`) for length normalization
+- `SearchIndex` tracks `avgDocLen` (mean document length), `docCount`, and `docFreq` (term → number of documents containing it)
+- Term maps remain per-document (no inverted index restructure)
+
+**BM25 formula per (query term, document) pair:**
+
+```
+score = IDF × (tf × (k1 + 1)) / (tf + k1 × (1 - b + b × docLen / avgDocLen))
+```
+
+Where:
+- `tf` = term frequency in the document (weighted by field — see section 3)
+- `IDF` = `ln((N - n + 0.5) / (n + 0.5) + 1)` — N is total docs, n is docs containing the term
+- `k1 = 1.2`, `b = 0.75` (standard defaults, defined as constants)
+- `docLen` = total weighted term count in this document
+- `avgDocLen` = mean document length across all notes
+
+A document's total score is the sum of BM25 scores across all query terms.
+
+**What this fixes:** Matches in short notes rank higher than the same word buried in long notes. Repeated terms don't inflate scores endlessly (term saturation).
+
+### 2. Prefix Matching
+
+During search, each query token is checked against indexed terms with a prefix match.
+
+**Behavior:**
+- `think` matches `think`, `thinkpad`, `thinking`, etc.
+- Prefix matching is one-directional: the query term is treated as a prefix of indexed terms, not the reverse. `thinkpad` in a query won't match indexed term `think`.
+- Minimum prefix length of 3 characters. Shorter query terms require exact match only, to avoid noise.
+- When a query term prefix-matches multiple indexed terms in the same document, their frequencies are summed as the tf value. E.g., query `comp` matching both `computer` and `components` combines their counts.
+
+**What this fixes:** The core failing scenarios from issue #3. `spec computer todo` now matches notes containing `specification`, `computer`, `todo-list` via prefix. `ThinkPad` matches content containing `thinkpad` as part of longer compounds.
+
+### 3. Field Boosting
+
+Replace the flat +3 title bonus with per-field weight multipliers applied during indexing.
+
+| Field | Weight | Rationale |
+|-------|--------|-----------|
+| title | 3.0 | Most signal-dense; what the note "is about" |
+| tags | 2.0 | Curated metadata, high intent |
+| related slugs | 1.5 | Cross-references indicate topical relevance |
+| body | 1.0 | Baseline — bulk content, noisier |
+
+**How it works:** During indexing, term frequency is incremented by `1 × field_weight`. BM25 then operates on these weighted frequencies naturally.
+
+**Trade-off:** Simpler than maintaining separate per-field indexes, but field weights can't be tuned at query time. Acceptable for this use case — weights are a property of the vault, not the query.
+
+### 4. API and Behavioral Changes
+
+**External interface:** No changes. `search_notes` keeps the same signature — `query` (string) + `limit` (optional number). `SearchResult` type unchanged.
+
+**Internal changes to `SearchIndex`:**
+- New private state: `avgDocLen`, `docCount`, `docFreq` map (term → document count) — computed during index build
+- `IndexEntry` gains a `docLen` field
+- `buildIndex` and `buildIndexWithContent` signatures unchanged
+
+**Excerpt generation:** Unchanged.
+
+**Score magnitude:** BM25 produces smaller numbers than raw TF + bonus. Scores are only used for relative ranking, never displayed or compared across queries.
+
+### 5. Testing Strategy
+
+**Existing tests to update:**
+- Title match scoring — assertion logic stays the same (title > tag) but expected values change
+- Multi-term query — more terms still score higher, values differ
+
+**New tests:**
+- Prefix matching — query `think` matches note containing `thinkpad`; `comp` matches `computer` and `components`
+- Minimum prefix length — 2-character query terms don't prefix-match (exact only)
+- BM25 document length normalization — same term in a short note scores higher than in a long note
+- BM25 term saturation — term appearing 10× doesn't score 10× higher than 1×
+- Field boosting — title match > tag match > related match > body match for the same term
+- Issue #3 regression — note titled "Hardware — ThinkPad X1 Carbon (Arch Laptop)" found by `ThinkPad` and `spec computer todo`
+
+**Integration tests:** Existing `mcpTools.test.ts` search tests assert on result presence, not scores — should pass without modification.
+
+## Scope
+
+**In scope:** BM25 scoring, prefix matching, field boosting — all within `SearchIndex.ts` and its tests.
+
+**Out of scope:** Fuzzy/typo tolerance (not needed for agent-authored vault), inverted index restructure (unnecessary at current scale, documented as future consideration in vault note `library/architecture/search-inverted-index-future`), boolean operators, phrase search.

--- a/server/src/search/SearchIndex.ts
+++ b/server/src/search/SearchIndex.ts
@@ -1,5 +1,8 @@
 import type { NoteListItem, SearchResult } from '../types.js';
 
+const BM25_K1 = 1.2;
+const BM25_B = 0.75;
+
 const FIELD_WEIGHTS = {
   title: 3.0,
   tags: 2.0,
@@ -72,10 +75,15 @@ export class SearchIndex {
     for (const entry of this.entries) {
       let score = 0;
       for (const term of queryTerms) {
-        const freq = entry.terms.get(term) || 0;
-        // Title matches score higher
-        const titleMatch = entry.frontmatter.title.toLowerCase().includes(term) ? 3 : 0;
-        score += freq + titleMatch;
+        const tf = entry.terms.get(term) || 0;
+        if (tf === 0) continue;
+
+        const n = this.docFreq.get(term) || 0;
+        const idf = Math.log((this.docCount - n + 0.5) / (n + 0.5) + 1);
+        const tfNorm =
+          (tf * (BM25_K1 + 1)) /
+          (tf + BM25_K1 * (1 - BM25_B + BM25_B * (entry.docLen / this.avgDocLen)));
+        score += idf * tfNorm;
       }
       if (score > 0) {
         results.push({

--- a/server/src/search/SearchIndex.ts
+++ b/server/src/search/SearchIndex.ts
@@ -1,46 +1,66 @@
 import type { NoteListItem, SearchResult } from '../types.js';
 
+const FIELD_WEIGHTS = {
+  title: 3.0,
+  tags: 2.0,
+  related: 1.5,
+  body: 1.0,
+} as const;
+
 interface IndexEntry {
   slug: string;
   frontmatter: NoteListItem['frontmatter'];
-  terms: Map<string, number>; // term -> frequency
+  terms: Map<string, number>; // term -> weighted frequency
+  docLen: number; // total weighted term count
   text: string; // for excerpts
 }
 
 export class SearchIndex {
   private entries: IndexEntry[] = [];
+  private avgDocLen = 0;
+  private docCount = 0;
+  private docFreq = new Map<string, number>(); // term -> number of docs containing it
 
   buildIndex(notes: NoteListItem[]): void {
     this.entries = notes.map((note) => {
+      const terms = new Map<string, number>();
+      let docLen = 0;
+
+      docLen += this.addWeightedTerms(terms, note.frontmatter.title, FIELD_WEIGHTS.title);
+      docLen += this.addWeightedTerms(terms, note.frontmatter.tags.join(' '), FIELD_WEIGHTS.tags);
+      docLen += this.addWeightedTerms(terms, note.frontmatter.related.join(' '), FIELD_WEIGHTS.related);
+
       const text = [
         note.frontmatter.title,
         ...note.frontmatter.tags,
         ...note.frontmatter.related,
       ].join(' ');
-      return {
-        slug: note.slug,
-        frontmatter: note.frontmatter,
-        terms: this.tokenize(text),
-        text,
-      };
+
+      return { slug: note.slug, frontmatter: note.frontmatter, terms, docLen, text };
     });
+    this.computeCorpusStats();
   }
 
   buildIndexWithContent(notes: Array<NoteListItem & { content: string }>): void {
     this.entries = notes.map((note) => {
+      const terms = new Map<string, number>();
+      let docLen = 0;
+
+      docLen += this.addWeightedTerms(terms, note.frontmatter.title, FIELD_WEIGHTS.title);
+      docLen += this.addWeightedTerms(terms, note.frontmatter.tags.join(' '), FIELD_WEIGHTS.tags);
+      docLen += this.addWeightedTerms(terms, note.frontmatter.related.join(' '), FIELD_WEIGHTS.related);
+      docLen += this.addWeightedTerms(terms, note.content, FIELD_WEIGHTS.body);
+
       const text = [
         note.frontmatter.title,
         ...note.frontmatter.tags,
         ...note.frontmatter.related,
         note.content,
       ].join(' ');
-      return {
-        slug: note.slug,
-        frontmatter: note.frontmatter,
-        terms: this.tokenize(text),
-        text,
-      };
+
+      return { slug: note.slug, frontmatter: note.frontmatter, terms, docLen, text };
     });
+    this.computeCorpusStats();
   }
 
   search(query: string, limit = 10): SearchResult[] {
@@ -70,13 +90,26 @@ export class SearchIndex {
     return results.sort((a, b) => b.score - a.score).slice(0, limit);
   }
 
-  private tokenize(text: string): Map<string, number> {
-    const terms = new Map<string, number>();
+  private addWeightedTerms(terms: Map<string, number>, text: string, weight: number): number {
     const words = text.toLowerCase().split(/\W+/).filter((w) => w.length > 1);
     for (const word of words) {
-      terms.set(word, (terms.get(word) || 0) + 1);
+      terms.set(word, (terms.get(word) || 0) + weight);
     }
-    return terms;
+    return words.length * weight;
+  }
+
+  private computeCorpusStats(): void {
+    this.docCount = this.entries.length;
+    this.docFreq.clear();
+
+    let totalLen = 0;
+    for (const entry of this.entries) {
+      totalLen += entry.docLen;
+      for (const term of entry.terms.keys()) {
+        this.docFreq.set(term, (this.docFreq.get(term) || 0) + 1);
+      }
+    }
+    this.avgDocLen = this.docCount > 0 ? totalLen / this.docCount : 0;
   }
 
   private tokenizeQuery(query: string): string[] {

--- a/server/src/search/SearchIndex.ts
+++ b/server/src/search/SearchIndex.ts
@@ -72,14 +72,20 @@ export class SearchIndex {
 
     const results: SearchResult[] = [];
 
+    // Precompute IDF per query term to avoid redundant O(entries) scans
+    const idfMap = new Map<string, number>();
+    for (const term of queryTerms) {
+      const n = this.getDocFrequency(term);
+      idfMap.set(term, Math.log((this.docCount - n + 0.5) / (n + 0.5) + 1));
+    }
+
     for (const entry of this.entries) {
       let score = 0;
       for (const term of queryTerms) {
         const tf = this.getTermFrequency(entry, term);
         if (tf === 0) continue;
 
-        const n = this.getDocFrequency(term);
-        const idf = Math.log((this.docCount - n + 0.5) / (n + 0.5) + 1);
+        const idf = idfMap.get(term)!;
         const tfNorm =
           (tf * (BM25_K1 + 1)) /
           (tf + BM25_K1 * (1 - BM25_B + BM25_B * (entry.docLen / this.avgDocLen)));

--- a/server/src/search/SearchIndex.ts
+++ b/server/src/search/SearchIndex.ts
@@ -75,10 +75,10 @@ export class SearchIndex {
     for (const entry of this.entries) {
       let score = 0;
       for (const term of queryTerms) {
-        const tf = entry.terms.get(term) || 0;
+        const tf = this.getTermFrequency(entry, term);
         if (tf === 0) continue;
 
-        const n = this.docFreq.get(term) || 0;
+        const n = this.getDocFrequency(term);
         const idf = Math.log((this.docCount - n + 0.5) / (n + 0.5) + 1);
         const tfNorm =
           (tf * (BM25_K1 + 1)) /
@@ -96,6 +96,29 @@ export class SearchIndex {
     }
 
     return results.sort((a, b) => b.score - a.score).slice(0, limit);
+  }
+
+  private getTermFrequency(entry: IndexEntry, queryTerm: string): number {
+    const exact = entry.terms.get(queryTerm) || 0;
+    if (queryTerm.length < 3) return exact;
+
+    let prefixSum = 0;
+    for (const [indexedTerm, freq] of entry.terms) {
+      if (indexedTerm !== queryTerm && indexedTerm.startsWith(queryTerm)) {
+        prefixSum += freq;
+      }
+    }
+    return exact + prefixSum;
+  }
+
+  private getDocFrequency(queryTerm: string): number {
+    if (queryTerm.length < 3) return this.docFreq.get(queryTerm) || 0;
+
+    let count = 0;
+    for (const entry of this.entries) {
+      if (this.getTermFrequency(entry, queryTerm) > 0) count++;
+    }
+    return count;
   }
 
   private addWeightedTerms(terms: Map<string, number>, text: string, weight: number): number {

--- a/server/src/search/__tests__/SearchIndex.test.ts
+++ b/server/src/search/__tests__/SearchIndex.test.ts
@@ -67,6 +67,37 @@ describe('SearchIndex', () => {
     expect(typeof results[0].excerpt).toBe('string');
   });
 
+  test('field boosting: title match > tag match > related match > body match', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'title-hit',
+        frontmatter: { title: 'Kubernetes Guide', date: '2026-01-01', tags: [], related: [] },
+        content: 'A guide about containers.',
+      },
+      {
+        slug: 'tag-hit',
+        frontmatter: { title: 'Container Guide', date: '2026-01-01', tags: ['kubernetes'], related: [] },
+        content: 'A guide about containers.',
+      },
+      {
+        slug: 'related-hit',
+        frontmatter: { title: 'Container Guide', date: '2026-01-01', tags: [], related: ['kubernetes-overview'] },
+        content: 'A guide about containers.',
+      },
+      {
+        slug: 'body-hit',
+        frontmatter: { title: 'Container Guide', date: '2026-01-01', tags: [], related: [] },
+        content: 'Learn about kubernetes orchestration.',
+      },
+    ]);
+    const results = index.search('kubernetes');
+    expect(results.length).toBe(4);
+    expect(results[0].slug).toBe('title-hit');
+    expect(results[1].slug).toBe('tag-hit');
+    expect(results[2].slug).toBe('related-hit');
+    expect(results[3].slug).toBe('body-hit');
+  });
+
   test('buildIndexWithContent indexes related slugs', () => {
     index.buildIndexWithContent([
       {

--- a/server/src/search/__tests__/SearchIndex.test.ts
+++ b/server/src/search/__tests__/SearchIndex.test.ts
@@ -200,6 +200,38 @@ describe('SearchIndex', () => {
     expect(results[0].excerpt.toLowerCase()).toContain('thinkpad');
   });
 
+  test('issue #3 regression: finds ThinkPad note by indirect queries', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'hardware/thinkpad-x1-carbon',
+        frontmatter: {
+          title: 'Hardware — ThinkPad X1 Carbon (Arch Laptop)',
+          date: '2026-01-01',
+          tags: ['hardware', 'laptop', 'arch-linux'],
+          related: [],
+        },
+        content:
+          'Spec sheet and setup notes for the ThinkPad X1 Carbon running Arch Linux. ' +
+          'Todo: document BIOS settings and power management.',
+      },
+      {
+        slug: 'projects/startup/index',
+        frontmatter: { title: 'Startup Project', date: '2026-01-01', tags: ['project'], related: [] },
+        content: 'Unrelated startup content.',
+      },
+    ]);
+
+    // "ThinkPad" — direct title term
+    const r1 = index.search('ThinkPad');
+    expect(r1.length).toBeGreaterThanOrEqual(1);
+    expect(r1[0].slug).toBe('hardware/thinkpad-x1-carbon');
+
+    // "spec laptop todo" — indirect multi-field query
+    const r2 = index.search('spec laptop todo');
+    expect(r2.length).toBeGreaterThanOrEqual(1);
+    expect(r2[0].slug).toBe('hardware/thinkpad-x1-carbon');
+  });
+
   test('buildIndexWithContent indexes related slugs', () => {
     index.buildIndexWithContent([
       {

--- a/server/src/search/__tests__/SearchIndex.test.ts
+++ b/server/src/search/__tests__/SearchIndex.test.ts
@@ -137,6 +137,56 @@ describe('SearchIndex', () => {
     expect(scoreTen).toBeGreaterThan(scoreOnce);
   });
 
+  test('prefix matching: query "think" matches note containing "thinkpad"', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'laptop',
+        frontmatter: { title: 'Hardware — ThinkPad X1 Carbon', date: '2026-01-01', tags: ['hardware'], related: [] },
+        content: 'Arch Linux laptop setup notes.',
+      },
+    ]);
+    const results = index.search('think');
+    expect(results).toHaveLength(1);
+    expect(results[0].slug).toBe('laptop');
+  });
+
+  test('prefix matching: sums frequencies when prefix matches multiple terms', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'a',
+        frontmatter: { title: 'Note', date: '2026-01-01', tags: [], related: [] },
+        content: 'computer components computation',
+      },
+    ]);
+    const results = index.search('comp');
+    expect(results).toHaveLength(1);
+    expect(results[0].score).toBeGreaterThan(0);
+  });
+
+  test('prefix matching: minimum length 3 — two-char terms require exact match', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'a',
+        frontmatter: { title: 'Note', date: '2026-01-01', tags: [], related: [] },
+        content: 'the theorem is theoretical',
+      },
+    ]);
+    const results = index.search('th');
+    expect(results).toHaveLength(0);
+  });
+
+  test('prefix matching: exact match still works for short terms', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'a',
+        frontmatter: { title: 'Go Language', date: '2026-01-01', tags: ['go'], related: [] },
+        content: 'Go is a compiled language.',
+      },
+    ]);
+    const results = index.search('go');
+    expect(results).toHaveLength(1);
+  });
+
   test('buildIndexWithContent indexes related slugs', () => {
     index.buildIndexWithContent([
       {

--- a/server/src/search/__tests__/SearchIndex.test.ts
+++ b/server/src/search/__tests__/SearchIndex.test.ts
@@ -98,6 +98,45 @@ describe('SearchIndex', () => {
     expect(results[3].slug).toBe('body-hit');
   });
 
+  test('BM25: same term in short note scores higher than in long note', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'short',
+        frontmatter: { title: 'Kubernetes', date: '2026-01-01', tags: [], related: [] },
+        content: '',
+      },
+      {
+        slug: 'long',
+        frontmatter: { title: 'Kubernetes', date: '2026-01-01', tags: [], related: [] },
+        content: 'word '.repeat(500),
+      },
+    ]);
+    const results = index.search('kubernetes');
+    expect(results.length).toBe(2);
+    expect(results[0].slug).toBe('short');
+  });
+
+  test('BM25: term saturation — 10 occurrences do not score 10x higher than 1', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'once',
+        frontmatter: { title: 'Note', date: '2026-01-01', tags: [], related: [] },
+        content: 'kubernetes is useful',
+      },
+      {
+        slug: 'ten-times',
+        frontmatter: { title: 'Note', date: '2026-01-01', tags: [], related: [] },
+        content: Array(10).fill('kubernetes').join(' and '),
+      },
+    ]);
+    const results = index.search('kubernetes');
+    const scoreOnce = results.find((r) => r.slug === 'once')!.score;
+    const scoreTen = results.find((r) => r.slug === 'ten-times')!.score;
+    // With saturation, 10x occurrences should score well under 5x (not 10x)
+    expect(scoreTen / scoreOnce).toBeLessThan(5);
+    expect(scoreTen).toBeGreaterThan(scoreOnce);
+  });
+
   test('buildIndexWithContent indexes related slugs', () => {
     index.buildIndexWithContent([
       {

--- a/server/src/search/__tests__/SearchIndex.test.ts
+++ b/server/src/search/__tests__/SearchIndex.test.ts
@@ -187,6 +187,19 @@ describe('SearchIndex', () => {
     expect(results).toHaveLength(1);
   });
 
+  test('excerpt includes context around prefix-matched term', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'a',
+        frontmatter: { title: 'Note', date: '2026-01-01', tags: [], related: [] },
+        content: 'The ThinkPad X1 Carbon is a great laptop for development work.',
+      },
+    ]);
+    const results = index.search('think');
+    expect(results).toHaveLength(1);
+    expect(results[0].excerpt.toLowerCase()).toContain('thinkpad');
+  });
+
   test('buildIndexWithContent indexes related slugs', () => {
     index.buildIndexWithContent([
       {


### PR DESCRIPTION
## Summary

Resolves #3 — search quality improvements for indirect and title-mismatch queries.

- **BM25 scoring** replaces raw term frequency + title bonus, handling term saturation and document length normalization
- **Prefix matching** for query terms 3+ characters (e.g., `think` matches `thinkpad`), with frequency summing across multiple prefix hits
- **Field-weighted indexing** with per-field multipliers: title (3×), tags (2×), related slugs (1.5×), body (1×)

No new dependencies. All changes contained within `SearchIndex.ts` and its tests.

## Test Plan

- [x] 9 new unit tests covering field boosting, BM25 length normalization, term saturation, prefix matching (4 tests), excerpt verification, and issue #3 regression
- [x] All 74 tests pass (65 existing + 9 new)
- [x] Clean TypeScript build
- [ ] Manual verification: search for indirect queries against a populated vault

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>