### PR TITLE
feat: update_note accepts frontmatter embedded in content

### DIFF
--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -307,7 +307,8 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
 
     test('returns error when title is absent and content has no frontmatter', () => {
       const result = resolveFrontmatterParams({ title: undefined, content: 'Just body text.', tags: undefined, related: undefined });
-      expect(result).toMatchObject({ ok: false, error: expect.stringContaining('title') });
+      expect(result).toMatchObject({ ok: false, error: expect.stringContaining('include it in frontmatter') });
+      expect(result.ok === false && result.error).not.toMatch(/frontmatter was detected/i);
     });
 
     test('strips frontmatter from content body when frontmatter is present', () => {

--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -313,7 +313,37 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
     test('strips frontmatter from content body when frontmatter is present', () => {
       const content = '---\ntitle: My Note\n---\n\nActual body here.';
       const result = resolveFrontmatterParams({ title: undefined, content, tags: undefined, related: undefined });
-      expect(result).toMatchObject({ ok: true, content: expect.not.stringContaining('---') });
+      expect(result).toMatchObject({ ok: true, content: 'Actual body here.' });
+    });
+
+    test('returns error with YAML details when content has malformed frontmatter', () => {
+      const content = '---\ntitle: foo: bar: baz\ntags: [unclosed\n---\nBody.';
+      const result = resolveFrontmatterParams({ title: undefined, content, tags: undefined, related: undefined });
+      expect(result).toMatchObject({ ok: false, error: expect.stringMatching(/yaml/i) });
+    });
+
+    test('explicit related overrides frontmatter related', () => {
+      const content = '---\ntitle: Note\nrelated:\n  - old/note\n---\nBody.';
+      const result = resolveFrontmatterParams({ title: undefined, content, tags: undefined, related: ['new/note'] });
+      expect(result).toMatchObject({ ok: true, related: ['new/note'] });
+    });
+
+    test('returns error when title is empty string', () => {
+      const result = resolveFrontmatterParams({ title: '', content: 'Body.', tags: undefined, related: undefined });
+      expect(result).toMatchObject({ ok: false, error: expect.stringContaining('title') });
+    });
+
+    test('round-trip: get_note raw output can be passed back to resolveFrontmatterParams', async () => {
+      await noteStore.upsert({ slug: 'inbox/round-trip-note', title: 'Round Trip Note', content: 'Round trip body.', tags: ['rt'] });
+      const note = await noteStore.get('inbox/round-trip-note');
+      expect(note).not.toBeNull();
+      const result = resolveFrontmatterParams({ title: undefined, content: note!.raw, tags: undefined, related: undefined });
+      expect(result).toMatchObject({ ok: true, title: 'Round Trip Note' });
+      if (result.ok) {
+        expect(result.content.trim()).toBe('Round trip body.');
+        expect(result.tags).toEqual(['rt']);
+        expect(result.content).not.toContain('---');
+      }
     });
   });
 

--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -302,7 +302,7 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
     test('returns error when title is absent and frontmatter has no title', () => {
       const content = '---\ntags:\n  - foo\n---\nBody text.';
       const result = resolveFrontmatterParams({ title: undefined, content, tags: undefined, related: undefined });
-      expect(result).toMatchObject({ ok: false, error: expect.stringContaining('title') });
+      expect(result).toMatchObject({ ok: false, error: expect.stringMatching(/frontmatter was detected/i) });
     });
 
     test('returns error when title is absent and content has no frontmatter', () => {
@@ -316,10 +316,10 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
       expect(result).toMatchObject({ ok: true, content: 'Actual body here.' });
     });
 
-    test('returns error with YAML details when content has malformed frontmatter', () => {
+    test('returns error with parse details when content has malformed frontmatter', () => {
       const content = '---\ntitle: foo: bar: baz\ntags: [unclosed\n---\nBody.';
       const result = resolveFrontmatterParams({ title: undefined, content, tags: undefined, related: undefined });
-      expect(result).toMatchObject({ ok: false, error: expect.stringMatching(/yaml/i) });
+      expect(result).toMatchObject({ ok: false, error: expect.stringMatching(/failed to parse/i) });
     });
 
     test('explicit related overrides frontmatter related', () => {
@@ -331,6 +331,22 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
     test('returns error when title is empty string', () => {
       const result = resolveFrontmatterParams({ title: '', content: 'Body.', tags: undefined, related: undefined });
       expect(result).toMatchObject({ ok: false, error: expect.stringContaining('title') });
+    });
+
+    test('returns error when frontmatter title is a number (e.g. title: 2024)', () => {
+      const content = '---\ntitle: 2024\ntags:\n  - year\n---\nBody.';
+      const result = resolveFrontmatterParams({ title: undefined, content, tags: undefined, related: undefined });
+      expect(result).toMatchObject({ ok: false, error: expect.stringContaining('title') });
+    });
+
+    test('update_note handler pattern: resolveFrontmatterParams error propagates as isError response', () => {
+      // Simulates the handler's error routing: if (!resolved.ok) return { isError: true, ... }
+      const resolved = resolveFrontmatterParams({ title: undefined, content: '---\ntags:\n  - foo\n---\nBody.', tags: undefined, related: undefined });
+      expect(resolved.ok).toBe(false);
+      if (!resolved.ok) {
+        const handlerResponse = { isError: true as const, content: [{ type: 'text' as const, text: resolved.error }] };
+        expect(handlerResponse).toMatchObject({ isError: true, content: [{ type: 'text', text: expect.stringContaining('title') }] });
+      }
     });
 
     test('round-trip: get_note raw output can be passed back to resolveFrontmatterParams', async () => {

--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -12,7 +12,7 @@ import { z } from 'zod';
 import { NoteStore } from '../../notes/NoteStore.js';
 import { SearchIndex } from '../../search/SearchIndex.js';
 import type { NoteListItem } from '../../types.js';
-import { coerceStringArray } from '../coerce.js';
+import { coerceStringArray, resolveFrontmatterParams } from '../coerce.js';
 import { vaultContextHandler } from '../server.js';
 
 async function makeTmpDir(): Promise<string> {
@@ -266,6 +266,54 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
       await expect(vaultContextHandler(dir)).rejects.toThrow(
         'profile.md not found — create it at the vault root.'
       );
+    });
+  });
+
+  describe('resolveFrontmatterParams', () => {
+    test('returns provided title and content unchanged when no frontmatter in content', () => {
+      const result = resolveFrontmatterParams({ title: 'My Note', content: 'Body text.', tags: undefined, related: undefined });
+      expect(result).toEqual({ ok: true, title: 'My Note', content: 'Body text.', tags: undefined, related: undefined });
+    });
+
+    test('extracts title from frontmatter when title param is absent', () => {
+      const content = '---\ntitle: Extracted Title\n---\nBody text.';
+      const result = resolveFrontmatterParams({ title: undefined, content, tags: undefined, related: undefined });
+      expect(result).toEqual({ ok: true, title: 'Extracted Title', content: 'Body text.', tags: undefined, related: undefined });
+    });
+
+    test('extracts tags and related from frontmatter along with title', () => {
+      const content = '---\ntitle: Full Note\ntags:\n  - foo\n  - bar\nrelated:\n  - other/note\n---\nBody text.';
+      const result = resolveFrontmatterParams({ title: undefined, content, tags: undefined, related: undefined });
+      expect(result).toEqual({ ok: true, title: 'Full Note', content: 'Body text.', tags: ['foo', 'bar'], related: ['other/note'] });
+    });
+
+    test('explicit title overrides frontmatter title', () => {
+      const content = '---\ntitle: Frontmatter Title\ntags:\n  - foo\n---\nBody text.';
+      const result = resolveFrontmatterParams({ title: 'Explicit Title', content, tags: undefined, related: undefined });
+      expect(result).toEqual({ ok: true, title: 'Explicit Title', content: 'Body text.', tags: ['foo'], related: undefined });
+    });
+
+    test('explicit tags override frontmatter tags', () => {
+      const content = '---\ntitle: Note\ntags:\n  - from-frontmatter\n---\nBody.';
+      const result = resolveFrontmatterParams({ title: undefined, content, tags: ['explicit-tag'], related: undefined });
+      expect(result).toEqual({ ok: true, title: 'Note', content: 'Body.', tags: ['explicit-tag'], related: undefined });
+    });
+
+    test('returns error when title is absent and frontmatter has no title', () => {
+      const content = '---\ntags:\n  - foo\n---\nBody text.';
+      const result = resolveFrontmatterParams({ title: undefined, content, tags: undefined, related: undefined });
+      expect(result).toMatchObject({ ok: false, error: expect.stringContaining('title') });
+    });
+
+    test('returns error when title is absent and content has no frontmatter', () => {
+      const result = resolveFrontmatterParams({ title: undefined, content: 'Just body text.', tags: undefined, related: undefined });
+      expect(result).toMatchObject({ ok: false, error: expect.stringContaining('title') });
+    });
+
+    test('strips frontmatter from content body when frontmatter is present', () => {
+      const content = '---\ntitle: My Note\n---\n\nActual body here.';
+      const result = resolveFrontmatterParams({ title: undefined, content, tags: undefined, related: undefined });
+      expect(result).toMatchObject({ ok: true, content: expect.not.stringContaining('---') });
     });
   });
 

--- a/server/src/mcp/coerce.ts
+++ b/server/src/mcp/coerce.ts
@@ -9,9 +9,9 @@ type ResolveFailed = { ok: false; error: string };
  * When an agent receives a note via get_note (which returns raw markdown including
  * frontmatter) and passes it back to update_note, the frontmatter is embedded in the
  * content string rather than as separate params. This function handles that round-trip:
- * if title is absent, it extracts title/tags/related from frontmatter in content and
- * strips the frontmatter from the body. Explicit params always take precedence over
- * frontmatter values.
+ * it extracts title/tags/related from frontmatter in content and strips the frontmatter
+ * from the body whenever frontmatter is present. Explicit params always take precedence
+ * over frontmatter values.
  */
 export function resolveFrontmatterParams(params: {
   title: string | undefined;
@@ -20,10 +20,19 @@ export function resolveFrontmatterParams(params: {
   related: string[] | undefined;
 }): ResolvedParams | ResolveFailed {
   const { tags, related } = params;
-  const parsed = matter(params.content);
+
+  let parsed: matter.GrayMatterFile<string>;
+  try {
+    parsed = matter(params.content);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    return { ok: false, error: `Invalid YAML frontmatter: ${msg}` };
+  }
+
   const hasFrontmatter = Object.keys(parsed.data).length > 0;
 
-  const title = params.title ?? (hasFrontmatter ? (parsed.data.title as string | undefined) : undefined);
+  const rawTitle = params.title ?? (hasFrontmatter ? parsed.data.title : undefined);
+  const title = typeof rawTitle === 'string' ? rawTitle : undefined;
   if (!title) {
     return { ok: false, error: 'title is required — pass it as a separate param or include it in frontmatter' };
   }

--- a/server/src/mcp/coerce.ts
+++ b/server/src/mcp/coerce.ts
@@ -1,3 +1,40 @@
+import matter from 'gray-matter';
+
+type ResolvedParams = { ok: true; title: string; content: string; tags?: string[]; related?: string[] };
+type ResolveFailed = { ok: false; error: string };
+
+/**
+ * Resolves update_note parameters, supporting frontmatter-embedded content.
+ *
+ * When an agent receives a note via get_note (which returns raw markdown including
+ * frontmatter) and passes it back to update_note, the frontmatter is embedded in the
+ * content string rather than as separate params. This function handles that round-trip:
+ * if title is absent, it extracts title/tags/related from frontmatter in content and
+ * strips the frontmatter from the body. Explicit params always take precedence over
+ * frontmatter values.
+ */
+export function resolveFrontmatterParams(params: {
+  title: string | undefined;
+  content: string;
+  tags: string[] | undefined;
+  related: string[] | undefined;
+}): ResolvedParams | ResolveFailed {
+  const { tags, related } = params;
+  const parsed = matter(params.content);
+  const hasFrontmatter = Object.keys(parsed.data).length > 0;
+
+  const title = params.title ?? (hasFrontmatter ? (parsed.data.title as string | undefined) : undefined);
+  if (!title) {
+    return { ok: false, error: 'title is required — pass it as a separate param or include it in frontmatter' };
+  }
+
+  const content = hasFrontmatter ? parsed.content.replace(/^\n/, '') : params.content;
+  const resolvedTags = tags ?? (hasFrontmatter ? coerceStringArray(parsed.data.tags) : undefined);
+  const resolvedRelated = related ?? (hasFrontmatter ? coerceStringArray(parsed.data.related) : undefined);
+
+  return { ok: true, title, content, tags: resolvedTags, related: resolvedRelated };
+}
+
 /**
  * Coerces an unknown input to string[] | undefined.
  *

--- a/server/src/mcp/coerce.ts
+++ b/server/src/mcp/coerce.ts
@@ -26,7 +26,7 @@ export function resolveFrontmatterParams(params: {
     parsed = matter(params.content);
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
-    return { ok: false, error: `Invalid YAML frontmatter: ${msg}` };
+    return { ok: false, error: `Failed to parse note content: ${msg}` };
   }
 
   const hasFrontmatter = Object.keys(parsed.data).length > 0;
@@ -34,6 +34,9 @@ export function resolveFrontmatterParams(params: {
   const rawTitle = params.title ?? (hasFrontmatter ? parsed.data.title : undefined);
   const title = typeof rawTitle === 'string' ? rawTitle : undefined;
   if (!title) {
+    if (hasFrontmatter) {
+      return { ok: false, error: 'title is required — frontmatter was detected in content but no title field was found. Pass title as a separate param or add a title field to the frontmatter.' };
+    }
     return { ok: false, error: 'title is required — pass it as a separate param or include it in frontmatter' };
   }
 

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -4,7 +4,7 @@ import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mc
 import { z } from 'zod';
 import { NoteStore } from '../notes/NoteStore.js';
 import { SearchIndex } from '../search/SearchIndex.js';
-import { coerceStringArray } from './coerce.js';
+import { coerceStringArray, resolveFrontmatterParams } from './coerce.js';
 
 export async function vaultContextHandler(notesDir: string) {
   try {
@@ -122,11 +122,13 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
 
   server.tool(
     'update_note',
-    'Update an existing note. Pass the slug to identify which note to update.',
+    'Update an existing note. Pass the slug to identify which note to update. ' +
+    'title, tags, and related can be passed as separate params or embedded as frontmatter in content — ' +
+    'useful when passing back output from get_note directly. Explicit params take precedence over frontmatter values.',
     {
       slug: z.string().describe('The slug of the note to update'),
-      title: z.string().describe('New title for the note'),
-      content: z.string().describe('New markdown content for the note body'),
+      title: z.string().optional().describe('New title for the note. Can also be supplied via frontmatter in content.'),
+      content: z.string().describe('New markdown content for the note body (frontmatter will be extracted if present)'),
       tags: z.preprocess(coerceStringArray, z.array(z.string()).optional()).describe('Updated tags'),
       related: z.preprocess(coerceStringArray, z.array(z.string()).optional()).describe('Updated related note slugs'),
     },
@@ -139,7 +141,11 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
           isError: true,
         };
       }
-      const note = await noteStore.upsert({ slug, title, content, tags, related });
+      const resolved = resolveFrontmatterParams({ title, content, tags, related });
+      if (!resolved.ok) {
+        return { isError: true, content: [{ type: 'text', text: resolved.error }] };
+      }
+      const note = await noteStore.upsert({ slug, ...resolved });
       const allNotes = await noteStore.listWithContent();
       searchIndex.buildIndexWithContent(allNotes);
       return {

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -111,9 +111,15 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
         };
       }
 
-      const note = await noteStore.upsert({ slug, title, content, tags, related });
-      const allNotes = await noteStore.listWithContent();
-      searchIndex.buildIndexWithContent(allNotes);
+      let note;
+      try {
+        note = await noteStore.upsert({ slug, title, content, tags, related });
+        const allNotes = await noteStore.listWithContent();
+        searchIndex.buildIndexWithContent(allNotes);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { isError: true, content: [{ type: 'text', text: `Failed to write note "${slug}": ${msg}` }] };
+      }
       return {
         content: [{ type: 'text', text: `Created note "${note.frontmatter.title}" with slug "${note.slug}".` }],
       };

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -145,7 +145,7 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
       if (!resolved.ok) {
         return { isError: true, content: [{ type: 'text', text: resolved.error }] };
       }
-      const note = await noteStore.upsert({ slug, ...resolved });
+      const note = await noteStore.upsert({ slug, title: resolved.title, content: resolved.content, tags: resolved.tags, related: resolved.related });
       const allNotes = await noteStore.listWithContent();
       searchIndex.buildIndexWithContent(allNotes);
       return {

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -145,9 +145,15 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
       if (!resolved.ok) {
         return { isError: true, content: [{ type: 'text', text: resolved.error }] };
       }
-      const note = await noteStore.upsert({ slug, title: resolved.title, content: resolved.content, tags: resolved.tags, related: resolved.related });
-      const allNotes = await noteStore.listWithContent();
-      searchIndex.buildIndexWithContent(allNotes);
+      let note;
+      try {
+        note = await noteStore.upsert({ slug, title: resolved.title, content: resolved.content, tags: resolved.tags, related: resolved.related });
+        const allNotes = await noteStore.listWithContent();
+        searchIndex.buildIndexWithContent(allNotes);
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        return { isError: true, content: [{ type: 'text', text: `Failed to write note "${slug}": ${msg}` }] };
+      }
       return {
         content: [{ type: 'text', text: `Updated note "${note.frontmatter.title}" (slug: "${note.slug}").` }],
       };


### PR DESCRIPTION
## Summary

- Adds `resolveFrontmatterParams()` utility that extracts `title`, `tags`, and `related` from frontmatter when they aren't passed as separate params
- Makes `title` optional in `update_note` schema — falls back to frontmatter extraction
- Explicit params always take precedence over frontmatter values
- Returns a descriptive error when `title` is absent from both params and frontmatter (previously: cryptic Zod type error)

## Motivation

`get_note` returns raw markdown including frontmatter. The natural agent pattern is to edit the content and pass it back to `update_note` — but that triggered `title - Invalid input: expected string, received undefined` because the tool expected `title` as a separate param. This closes the round-trip gap.

## Test Plan

- [x] `resolveFrontmatterParams` unit tests cover: title extraction, tags/related extraction, explicit-param precedence, error cases (missing title in both params and frontmatter)
- [x] Full test suite passes (82 tests)

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)