### PR TITLE
fix(coerce): treat empty tags/related arrays as preserve, not clear (#41)

### DIFF
--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -449,6 +449,18 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
       }
     });
 
+    test('frontmatter tags: [] is normalized to undefined (preserve-existing semantics)', () => {
+      // Paranoia check: confirms the empty-array→undefined fix from coerceStringArray
+      // propagates through resolveFrontmatterParams when frontmatter contains `tags: []`.
+      const result = resolveFrontmatterParams({
+        title: undefined,
+        content: '---\ntitle: Foo\ntags: []\n---\nBody.',
+        tags: undefined,
+        related: undefined,
+      });
+      expect(result).toMatchObject({ ok: true, title: 'Foo', tags: undefined });
+    });
+
     test('round-trip: get_note raw output can be passed back to resolveFrontmatterParams', async () => {
       await noteStore.upsert({ slug: 'inbox/round-trip-note', title: 'Round Trip Note', content: 'Round trip body.', tags: ['rt'] });
       const note = await noteStore.get('inbox/round-trip-note');
@@ -533,6 +545,125 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
 
     test('trims whitespace from comma-separated values', () => {
       expect(coerceStringArray('  tag1 ,  tag2  ')).toEqual(['tag1', 'tag2']);
+    });
+
+    // Empty-array → undefined: protects the update_note round-trip pattern from
+    // accidentally wiping existing tags/related when an LLM emits `tags: []`.
+    test('returns undefined for an empty array (preserve-existing semantics)', () => {
+      expect(coerceStringArray([])).toBeUndefined();
+    });
+
+    test('returns undefined for a JSON-encoded empty array string', () => {
+      expect(coerceStringArray('[]')).toBeUndefined();
+    });
+
+    test('preserves a non-empty array (sanity — fix does not affect non-empty input)', () => {
+      expect(coerceStringArray(['a'])).toEqual(['a']);
+    });
+
+    test('still splits a comma-separated string (sanity — fix does not affect comma path)', () => {
+      expect(coerceStringArray('a, b')).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('update_note empty-array preserve-existing semantics', () => {
+    // These tests simulate the exact handler flow from server.ts:
+    //   coerceStringArray (via z.preprocess) → resolveFrontmatterParams → noteStore.upsert
+    // ensuring that an LLM passing `tags: []` or `related: []` doesn't wipe existing values.
+    const tagsSchema = z.preprocess(coerceStringArray, z.array(z.string()).optional());
+    const relatedSchema = z.preprocess(coerceStringArray, z.array(z.string()).optional());
+
+    test('update_note { tags: [] } preserves existing tags on the stored note', async () => {
+      // Setup: create a note with tags
+      await noteStore.upsert({ slug: 'has-tags', title: 'Has Tags', content: 'Body.', tags: ['a', 'b'] });
+
+      // Simulate handler: schema preprocesses [] → undefined
+      const tagsInput: unknown = [];
+      const tags = tagsSchema.parse(tagsInput);
+      const related = relatedSchema.parse(undefined);
+      expect(tags).toBeUndefined();
+
+      const resolved = resolveFrontmatterParams({ title: 'Has Tags', content: 'Body.', tags, related });
+      expect(resolved.ok).toBe(true);
+      if (!resolved.ok) return;
+
+      await noteStore.upsert({ slug: 'has-tags', title: resolved.title, content: resolved.content, tags: resolved.tags, related: resolved.related });
+      const stored = await noteStore.get('has-tags');
+      expect(stored).not.toBeNull();
+      expect(stored!.frontmatter.tags).toEqual(['a', 'b']);
+    });
+
+    test('update_note { related: [] } preserves existing related on the stored note', async () => {
+      await noteStore.upsert({ slug: 'has-related', title: 'Has Related', content: 'Body.', related: ['other/note'] });
+
+      const tags = tagsSchema.parse(undefined);
+      const related = relatedSchema.parse([]);
+      expect(related).toBeUndefined();
+
+      const resolved = resolveFrontmatterParams({ title: 'Has Related', content: 'Body.', tags, related });
+      expect(resolved.ok).toBe(true);
+      if (!resolved.ok) return;
+
+      await noteStore.upsert({ slug: 'has-related', title: resolved.title, content: resolved.content, tags: resolved.tags, related: resolved.related });
+      const stored = await noteStore.get('has-related');
+      expect(stored).not.toBeNull();
+      expect(stored!.frontmatter.related).toEqual(['other/note']);
+    });
+
+    test('update_note round-trip via frontmatter with tags: [] preserves existing tags', async () => {
+      await noteStore.upsert({ slug: 'rt-note', title: 'Round Trip', content: 'Body.', tags: ['keep', 'these'] });
+
+      // Simulate an LLM passing back content with frontmatter that has empty tags.
+      // (e.g. it serialized the modified note but stripped the tag values.)
+      const roundTripContent = '---\ntitle: Round Trip\ntags: []\nrelated: []\n---\nUpdated body.';
+      const tags = tagsSchema.parse(undefined);
+      const related = relatedSchema.parse(undefined);
+
+      const resolved = resolveFrontmatterParams({ title: undefined, content: roundTripContent, tags, related });
+      expect(resolved.ok).toBe(true);
+      if (!resolved.ok) return;
+      // The fix's payoff: empty arrays in frontmatter become undefined, so upsert preserves.
+      expect(resolved.tags).toBeUndefined();
+      expect(resolved.related).toBeUndefined();
+
+      await noteStore.upsert({ slug: 'rt-note', title: resolved.title, content: resolved.content, tags: resolved.tags, related: resolved.related });
+      const stored = await noteStore.get('rt-note');
+      expect(stored).not.toBeNull();
+      expect(stored!.frontmatter.tags).toEqual(['keep', 'these']);
+      expect(stored!.content.trim()).toBe('Updated body.');
+    });
+
+    test('create_note with tags: [] still produces a note with empty tags (no regression)', async () => {
+      // For create, [] semantically means "no tags" — a brand-new note has no
+      // existing tags to preserve, so the note should land with tags: [].
+      // Path: schema → undefined → noteStore.upsert sees data.tags=undefined,
+      // existing=null, so frontmatter.tags falls back to [].
+      const tagsInput: unknown = [];
+      const tags = tagsSchema.parse(tagsInput);
+      expect(tags).toBeUndefined();
+
+      const note = await noteStore.upsert({ slug: 'fresh-note', title: 'Fresh', content: 'New body.', tags });
+      expect(note.frontmatter.tags).toEqual([]);
+
+      const stored = await noteStore.get('fresh-note');
+      expect(stored).not.toBeNull();
+      expect(stored!.frontmatter.tags).toEqual([]);
+    });
+
+    test('update_note { tags: ["new"] } against existing ["old"] still replaces tags (sanity)', async () => {
+      await noteStore.upsert({ slug: 'replace-tags', title: 'Replace', content: 'Body.', tags: ['old'] });
+
+      const tags = tagsSchema.parse(['new']);
+      const related = relatedSchema.parse(undefined);
+      expect(tags).toEqual(['new']);
+
+      const resolved = resolveFrontmatterParams({ title: 'Replace', content: 'Body.', tags, related });
+      expect(resolved.ok).toBe(true);
+      if (!resolved.ok) return;
+
+      await noteStore.upsert({ slug: 'replace-tags', title: resolved.title, content: resolved.content, tags: resolved.tags, related: resolved.related });
+      const stored = await noteStore.get('replace-tags');
+      expect(stored!.frontmatter.tags).toEqual(['new']);
     });
   });
 });

--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -665,5 +665,31 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
       const stored = await noteStore.get('replace-tags');
       expect(stored!.frontmatter.tags).toEqual(['new']);
     });
+
+    test('explicit tags: [] + frontmatter tags: [non-empty] — frontmatter wins (documents precedence)', async () => {
+      // After the empty-array → undefined coercion, an explicit `tags: []` no
+      // longer beats frontmatter tags. This is a deliberate trade-off: the
+      // ambiguity of `tags: []` (does it mean "clear" or "didn't change"?) is
+      // resolved by trusting whatever the body's frontmatter explicitly states.
+      // Prior to the fix, explicit `[]` would have wiped both existing tags and
+      // the frontmatter tags. PR #30's "explicit params take precedence" still
+      // holds for non-empty explicit values.
+      await noteStore.upsert({ slug: 'precedence-note', title: 'Precedence', content: 'Old body.', tags: ['existing'] });
+
+      const tags = tagsSchema.parse([]); // explicit empty → coerced to undefined
+      const related = relatedSchema.parse(undefined);
+      expect(tags).toBeUndefined();
+
+      const fmContent = '---\ntitle: Precedence\ntags:\n  - fm-tag\n---\nNew body.';
+      const resolved = resolveFrontmatterParams({ title: undefined, content: fmContent, tags, related });
+      expect(resolved.ok).toBe(true);
+      if (!resolved.ok) return;
+      // Frontmatter tags win because the explicit param coerced to undefined.
+      expect(resolved.tags).toEqual(['fm-tag']);
+
+      await noteStore.upsert({ slug: 'precedence-note', title: resolved.title, content: resolved.content, tags: resolved.tags, related: resolved.related });
+      const stored = await noteStore.get('precedence-note');
+      expect(stored!.frontmatter.tags).toEqual(['fm-tag']);
+    });
   });
 });

--- a/server/src/mcp/coerce.ts
+++ b/server/src/mcp/coerce.ts
@@ -56,16 +56,25 @@ export function resolveFrontmatterParams(params: {
  * - A single bare string: 'tag1'
  * - An already-correct array: ['tag1', 'tag2']
  * - A JSON-encoded non-array (e.g. '42', '{"a":1}'): treated as a plain string, comma-split
+ * - An empty array (`[]` or `'[]'`): coerced to `undefined` so downstream callers
+ *   treat it as "preserve existing" rather than "clear all". This guards the
+ *   round-trip pattern (get_note → modify → update_note) where LLMs often emit
+ *   `tags: []` to mean "I didn't change tags."
  */
 export function coerceStringArray(val: unknown): string[] | undefined {
   if (val === undefined || val === null) return undefined;
-  if (Array.isArray(val)) return val.map(String);
+  // Empty arrays are treated as "preserve existing" rather than "clear all".
+  // This protects the round-trip pattern (get_note → modify → update_note) where
+  // LLM clients commonly emit `tags: []` to mean "I didn't change tags." If
+  // explicit clearing is ever needed, add an explicit sentinel (e.g. a dedicated
+  // flag) rather than overloading the empty-array meaning.
+  if (Array.isArray(val)) return val.length === 0 ? undefined : val.map(String);
   if (typeof val === 'string') {
     const trimmed = val.trim();
     if (trimmed === '') return undefined;
     try {
       const parsed = JSON.parse(trimmed);
-      if (Array.isArray(parsed)) return parsed.map(String);
+      if (Array.isArray(parsed)) return parsed.length === 0 ? undefined : parsed.map(String);
     } catch {
       // not JSON — fall through to comma split
     }

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -153,7 +153,8 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
     'update_note',
     'Update an existing note. Pass the slug to identify which note to update. ' +
     'title, tags, and related can be passed as separate params or embedded as frontmatter in content — ' +
-    'useful when passing back output from get_note directly. Explicit params take precedence over frontmatter values.',
+    'useful when passing back output from get_note directly. Explicit params take precedence over frontmatter values. ' +
+    'Omit tags or related (or pass an empty array) to preserve existing values; pass a non-empty array to replace them.',
     {
       slug: z.string().describe('The slug of the note to update'),
       title: z.string().optional().describe('New title for the note. Can also be supplied via frontmatter in content.'),


### PR DESCRIPTION
## Summary

- LLM clients calling `update_note { tags: [] }` or `{ related: [] }` silently wiped existing values; same trap fired in the `get_note → modify → update_note` round-trip when the LLM emitted content with `tags: []` in frontmatter
- Fixes at the LLM-input boundary in `coerceStringArray`: empty arrays (both raw `[]` and JSON-encoded `'[]'`) now coerce to `undefined`, which propagates through `resolveFrontmatterParams` to land at `NoteStore.upsert` as the existing-value-preserving branch
- `NoteStore.upsert`'s API is intentionally unchanged — internal callers can still pass `tags: []` to mean "clear." Only LLM input gets the safety net

Closes #41.

## Design rationale

Two prior PRs established the relevant philosophy:
- **PR #7** (closes #1) created `coerceStringArray` specifically to make the `tags`/`related` interface forgiving for LLM clients
- **PR #30** (closes #25) created `resolveFrontmatterParams` to close the `get_note → update_note` round-trip gap

This PR extends both: the empty-array case was an unhandled hole in the same round-trip story. If explicit clearing is ever needed from the LLM, a dedicated sentinel (e.g. a `clearTags: true` flag) is preferable to overloading `[]`.

## Subtle behavior change worth noting

PR #30 documented "Explicit params take precedence over frontmatter values." That guarantee still holds for non-empty explicit values. For the specific input `tags: []` (explicit empty array) **plus** content with non-empty `tags` in frontmatter, behavior changes:

- Before: explicit `[]` won, stored as `[]` (this was the bug — empty tags wiped)
- After: explicit `[]` coerces to `undefined`, frontmatter tags win

This is the intended trade-off — `tags: []` is ambiguous ("clear" vs "didn't change") and we resolve by trusting whatever the body's frontmatter explicitly states. A new test documents this precedence behavior.

## Changes

- `server/src/mcp/coerce.ts` — empty-array → `undefined` in both the raw-array and JSON-parsed-array branches; JSDoc + inline comment explain rationale
- `server/src/mcp/server.ts` — `update_note` tool description states preserve-vs-replace semantics so the LLM has the right mental model
- `create_note` semantics unchanged: a fresh note with `tags: []` still lands with empty tags (no existing values to preserve from)

## Test plan

- [x] `npx jest` — 139 tests pass (was 128 on main; +11 new)
- [x] `npx tsc --noEmit` — clean
- [x] `coerceStringArray` direct tests: `[]` → undefined, `'[]'` → undefined, non-empty preserved, comma-string still splits
- [x] `resolveFrontmatterParams` paranoia: `tags: []` in frontmatter normalizes to undefined
- [x] End-to-end via the actual handler flow (schema preprocess → `resolveFrontmatterParams` → `noteStore.upsert`):
  - `update_note { tags: [] }` against existing `['a', 'b']` → tags preserved
  - `update_note { related: [] }` against existing `['other/note']` → related preserved
  - Round-trip via frontmatter with `tags: []` preserves existing tags
  - `create_note { tags: [] }` still produces a note with empty tags (regression check)
  - `update_note { tags: ['new'] }` against existing `['old']` still replaces (sanity)
  - Explicit `tags: []` + frontmatter `tags: [non-empty]` → frontmatter wins (documents precedence change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)