### PR TITLE
fix(move): atomic create-or-fail, rollback, self-ref (#42, #44)

### DIFF
--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -494,24 +494,11 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
       expect(searchResults[0].slug).toBe('new-slug');
     });
 
-    test('move_note with force overwrites existing target', async () => {
-      await noteStore.upsert({ slug: 'source', title: 'Source', content: 'Keep this.' });
-      await noteStore.upsert({ slug: 'target', title: 'Target', content: 'Overwrite this.' });
-
-      // Simulate force: delete target first, then move
-      await noteStore.delete('target');
-      const result = await noteStore.move('source', 'target');
-
-      expect(result.note.slug).toBe('target');
-      expect(result.note.frontmatter.title).toBe('Source');
-      expect(result.note.content.trim()).toBe('Keep this.');
-    });
-
     test('move_note rejects when source does not exist', async () => {
       await expect(noteStore.move('nonexistent', 'target')).rejects.toThrow('not found');
     });
 
-    test('move_note rejects when target exists without force', async () => {
+    test('move_note rejects when target already exists', async () => {
       await noteStore.upsert({ slug: 'src', title: 'Src', content: 'A.' });
       await noteStore.upsert({ slug: 'dst', title: 'Dst', content: 'B.' });
       await expect(noteStore.move('src', 'dst')).rejects.toThrow('already exists');

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -257,13 +257,12 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
     'move_note',
     'Move a note to a new location in the vault. Preserves all metadata (title, date, tags, related) ' +
     'and automatically updates related fields in other notes that reference the old slug. ' +
-    'Use force to overwrite an existing note at the target location.',
+    'Fails if a note already exists at the target slug — delete it first if you intend to replace.',
     {
       slug: z.string().describe('The current slug of the note to move'),
       new_slug: z.string().describe('The target slug to move the note to'),
-      force: z.boolean().optional().describe('If true, overwrite an existing note at the target slug (default: false)'),
     },
-    async ({ slug, new_slug, force }) => {
+    async ({ slug, new_slug }) => {
       if (!isValidSlug(slug)) return slugValidationError(slug);
       if (!isValidSlug(new_slug)) return slugValidationError(new_slug);
       if (slug === new_slug) {
@@ -271,19 +270,7 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
       }
 
       try {
-        if (!force) {
-          const existing = await noteStore.get(new_slug);
-          if (existing) {
-            return {
-              isError: true,
-              content: [{ type: 'text', text: `Note already exists at "${new_slug}" — pass force: true to overwrite, or choose a different slug.` }],
-            };
-          }
-        } else {
-          await noteStore.delete(new_slug);
-        }
-
-        const { note, updatedRefs } = await noteStore.move(slug, new_slug);
+        const { updatedRefs } = await noteStore.move(slug, new_slug);
         const allNotes = await noteStore.listWithContent();
         searchIndex.buildIndexWithContent(allNotes);
 
@@ -294,6 +281,13 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
         return { content: [{ type: 'text', text: msg }] };
       } catch (e) {
         const msg = e instanceof Error ? e.message : String(e);
+        // Surface the "already exists" case with user-friendly guidance.
+        if (msg.startsWith(`Note already exists at "${new_slug}"`)) {
+          return {
+            isError: true,
+            content: [{ type: 'text', text: `Note already exists at "${new_slug}" — choose a different slug.` }],
+          };
+        }
         return { isError: true, content: [{ type: 'text', text: `Failed to move note "${slug}": ${msg}` }] };
       }
     }

--- a/server/src/notes/NoteStore.ts
+++ b/server/src/notes/NoteStore.ts
@@ -239,6 +239,14 @@ export class NoteStore extends EventEmitter {
   }
 
   async move(oldSlug: string, newSlug: string): Promise<{ note: Note; updatedRefs: string[] }> {
+    // Defense-in-depth: same-slug move would otherwise fail at step 3 with a
+    // misleading "already exists" error (the source's own file is still on
+    // disk). Reject explicitly so callers see the real cause. The MCP handler
+    // already guards this upstream; this protects any direct caller.
+    if (oldSlug === newSlug) {
+      throw new Error(`Source and target slugs are the same: "${oldSlug}"`);
+    }
+
     // 1. Read source note
     const source = await this.get(oldSlug);
     if (!source) {
@@ -250,6 +258,12 @@ export class NoteStore extends EventEmitter {
     //    stringify with gray-matter ONLY in this case so the verbatim raw
     //    content path (preserving the user's exact YAML) holds for the common
     //    case where there's no self-reference.
+    //
+    //    Trade-off: matter.stringify serializes frontmatter in JS object
+    //    property order, which may differ from the user's hand-edited field
+    //    order. Acceptable because (a) the rewrite path only fires for self-
+    //    referencing notes, (b) the alternative is leaving a dangling related
+    //    entry pointing at a deleted slug.
     const oldPath = this.notePath(oldSlug);
     const newPath = this.notePath(newSlug);
     let content: string;
@@ -267,6 +281,12 @@ export class NoteStore extends EventEmitter {
     //    if the file already exists, closing the TOCTOU window between an
     //    existence check and a write. The try/finally ensures we close the
     //    handle even if the write throws.
+    //
+    //    Known small gap: if writeFile succeeds but close() throws (extremely
+    //    rare on local filesystems — kernel has already buffered the data),
+    //    the exception bypasses step 4 and the vault is left with a duplicate
+    //    note rather than a clean rollback. Worst case is duplication, not
+    //    data loss; not worth the structural complexity to handle.
     await fs.mkdir(path.dirname(newPath), { recursive: true });
     let fileHandle: fs.FileHandle;
     try {

--- a/server/src/notes/NoteStore.ts
+++ b/server/src/notes/NoteStore.ts
@@ -245,26 +245,64 @@ export class NoteStore extends EventEmitter {
       throw new Error(`Note "${oldSlug}" not found`);
     }
 
-    // 2. Check target doesn't exist
-    const existing = await this.get(newSlug);
-    if (existing) {
-      throw new Error(`Note already exists at "${newSlug}"`);
+    // 2. Self-ref preflight: if the source's own related[] references its old
+    //    slug, rewrite that one entry to the new slug before writing. We re-
+    //    stringify with gray-matter ONLY in this case so the verbatim raw
+    //    content path (preserving the user's exact YAML) holds for the common
+    //    case where there's no self-reference.
+    const oldPath = this.notePath(oldSlug);
+    const newPath = this.notePath(newSlug);
+    let content: string;
+    if (source.frontmatter.related.includes(oldSlug)) {
+      const newFrontmatter: NoteFrontmatter = {
+        ...source.frontmatter,
+        related: source.frontmatter.related.map((r) => (r === oldSlug ? newSlug : r)),
+      };
+      content = matter.stringify(source.content, newFrontmatter as unknown as Record<string, unknown>);
+    } else {
+      content = source.raw;
     }
 
-    // 3. Write to new location (preserving all frontmatter)
-    const newPath = this.notePath(newSlug);
+    // 3. Atomic create-or-fail at the target. The 'wx' flag fails with EEXIST
+    //    if the file already exists, closing the TOCTOU window between an
+    //    existence check and a write. The try/finally ensures we close the
+    //    handle even if the write throws.
     await fs.mkdir(path.dirname(newPath), { recursive: true });
-    await fs.writeFile(newPath, source.raw);
+    let fileHandle: fs.FileHandle;
+    try {
+      fileHandle = await fs.open(newPath, 'wx');
+    } catch (e) {
+      if ((e as NodeJS.ErrnoException).code === 'EEXIST') {
+        throw new Error(`Note already exists at "${newSlug}"`);
+      }
+      throw e;
+    }
+    try {
+      await fileHandle.writeFile(content);
+    } finally {
+      await fileHandle.close();
+    }
 
-    // 4. Delete old file and prune empty parents
-    const oldPath = this.notePath(oldSlug);
-    await fs.unlink(oldPath);
+    // 4. Unlink old file. If this fails, roll back the new-location write so
+    //    the pre-move state is restored exactly. The rollback is safe because
+    //    step 3 used 'wx' — the file at newPath was a brand new file we just
+    //    created, so deleting it cannot clobber pre-existing data.
+    try {
+      await fs.unlink(oldPath);
+    } catch (e) {
+      await fs.unlink(newPath).catch(() => {});
+      throw e;
+    }
+
+    // 5. Prune empty parents at the old location.
     await this.pruneEmptyParents(oldPath);
 
-    // 5. Update references in other notes
+    // 6. Update references in other notes. The moved note's own self-ref was
+    //    already handled in step 2, so updateRelatedRefs's `entry.slug ===
+    //    newSlug` skip-guard is correct here.
     const updatedRefs = await this.updateRelatedRefs(oldSlug, newSlug);
 
-    // 6. Return note at new location
+    // 7. Return note at new location
     const note = await this.get(newSlug);
     return { note: note!, updatedRefs };
   }

--- a/server/src/notes/__tests__/NoteStore.test.ts
+++ b/server/src/notes/__tests__/NoteStore.test.ts
@@ -377,6 +377,19 @@ describe('NoteStore', () => {
       await expect(store.move('source', 'target')).rejects.toThrow('already exists');
     });
 
+    test('move throws a clear error when source and target slugs match', async () => {
+      // Defense-in-depth: without the early guard, this would fail at the wx
+      // open step with a misleading "already exists" error.
+      await store.upsert({ slug: 'same-slug', title: 'Same', content: 'Body.' });
+      await expect(store.move('same-slug', 'same-slug')).rejects.toThrow(
+        /Source and target slugs are the same/
+      );
+      // Source must remain intact.
+      const stored = await store.get('same-slug');
+      expect(stored).not.toBeNull();
+      expect(stored!.frontmatter.title).toBe('Same');
+    });
+
     test('move updates related fields in other notes that reference old slug', async () => {
       await store.upsert({ slug: 'target-note', title: 'Target', content: 'Body.' });
       await store.upsert({ slug: 'referrer-a', title: 'A', content: 'Body.', related: ['target-note', 'other'] });

--- a/server/src/notes/__tests__/NoteStore.test.ts
+++ b/server/src/notes/__tests__/NoteStore.test.ts
@@ -407,6 +407,75 @@ describe('NoteStore', () => {
       const result = await store.move('lonely', 'still-lonely');
       expect(result.updatedRefs).toEqual([]);
     });
+
+    test('move rewrites self-reference in moved note\'s related[]', async () => {
+      // The moved note's own related[] referenced its old slug. After the move,
+      // that entry should point to the new slug (not the now-stale old slug).
+      await store.upsert({
+        slug: 'old-slug',
+        title: 'Self Ref',
+        content: 'Body.',
+        related: ['old-slug', 'other-slug'],
+      });
+
+      const result = await store.move('old-slug', 'new-slug');
+
+      expect(result.note.frontmatter.related).toEqual(['new-slug', 'other-slug']);
+      // Read from disk to confirm persistence (not just the in-memory return).
+      const persisted = await store.get('new-slug');
+      expect(persisted!.frontmatter.related).toEqual(['new-slug', 'other-slug']);
+    });
+
+    test('move preserves other frontmatter fields when rewriting self-reference', async () => {
+      // Self-ref rewrite path uses matter.stringify; ensure other fields survive.
+      await store.upsert({
+        slug: 'old-slug',
+        title: 'Self Ref',
+        content: 'Body.',
+        tags: ['a'],
+        related: ['old-slug'],
+      });
+
+      const result = await store.move('old-slug', 'new-slug');
+
+      expect(result.note.frontmatter.title).toBe('Self Ref');
+      expect(result.note.frontmatter.tags).toEqual(['a']);
+      expect(result.note.frontmatter.related).toEqual(['new-slug']);
+    });
+
+    test('move rolls back the new file when source unlink fails', async () => {
+      // Simulate a partial-failure mid-move: target write succeeds, source
+      // unlink throws. The post-condition must restore the pre-move state —
+      // source intact, target absent.
+      await store.upsert({ slug: 'src', title: 'Src', content: 'Body.' });
+
+      const sourcePath = path.join(dir, 'src.md');
+      const targetPath = path.join(dir, 'dst.md');
+      const realUnlink = fs.unlink.bind(fs);
+      const unlinkSpy = jest.spyOn(fs, 'unlink').mockImplementation(async (p) => {
+        // Only fail the source-unlink during move(); let the rollback unlink
+        // (and any other unlinks) hit the real implementation so the test
+        // can clean up and inspect filesystem state correctly.
+        if (typeof p === 'string' && p === sourcePath) {
+          throw Object.assign(new Error('EACCES: simulated permission denied'), { code: 'EACCES' });
+        }
+        return realUnlink(p as Parameters<typeof realUnlink>[0]);
+      });
+
+      try {
+        await expect(store.move('src', 'dst')).rejects.toThrow(/EACCES/);
+
+        // The simulated source-unlink fired (and rollback was triggered).
+        expect(unlinkSpy).toHaveBeenCalledWith(sourcePath);
+
+        // Source still exists (unlink failed before deletion).
+        await expect(fs.access(sourcePath)).resolves.toBeUndefined();
+        // Target was rolled back.
+        await expect(fs.access(targetPath)).rejects.toThrow();
+      } finally {
+        unlinkSpy.mockRestore();
+      }
+    });
   });
 
   describe('watcher', () => {


### PR DESCRIPTION
## Summary

Fixes three correctness bugs in `NoteStore.move()` and removes the unused `force` parameter from `move_note`.

- **Atomic create-or-fail at the target** via `fs.open(newPath, 'wx')` — closes the get-then-write TOCTOU window
- **Self-reference preflight** — if the moved note's own \`related\` array includes \`oldSlug\`, rewrite that entry before the write so the post-move note has a valid \`related: [newSlug, ...]\`. The verbatim raw-content path is preserved for the common (no-self-ref) case so the user's exact YAML formatting is untouched
- **Rollback on partial failure** — if \`unlink(oldPath)\` throws after the target write succeeded, \`unlink(newPath)\` undoes the wx-created file before re-throwing. Safe because \`wx\` guarantees \`newPath\` was a brand-new file we created
- **\`force\` removed from \`move_note\`** — no documented use case; agent-as-author philosophy doesn't favor silent overwrites. Callers that genuinely want to replace can do \`delete_note\` + \`move_note\` explicitly. Full design rationale: https://github.com/ethanaubuchon/dossier-mcp/issues/44#issuecomment-4364574924

Closes #42.
Closes #44.

## Why fix and remove together

The atomicity refactor naturally produced a cleaner API where \`force\` had no place. Keeping force would have meant two code paths (wx for force=false, plain writeFile for force=true) with different rollback semantics. Removing it keeps \`move()\` single-mode and easier to reason about.

## Test plan

- [x] \`npx jest\` — 141 tests pass (was 139 on main; +3 NoteStore, −1 mcpTools)
- [x] \`npx tsc --noEmit\` — clean
- [x] **Self-ref**: create note with \`related: ['old-slug', 'other-slug']\`, move \`old-slug → new-slug\` → \`related\` is \`['new-slug', 'other-slug']\`. Reads from disk to confirm persistence
- [x] **Self-ref preserves other fields**: re-stringifying via gray-matter doesn't drop \`tags\` etc.
- [x] **Rollback**: \`jest.spyOn(fs, 'unlink')\` with selective implementation that fails ONLY the source unlink → \`move()\` rejects, source intact, target absent. Rollback's own \`unlink(newPath)\` hits the real fs so the test assertion is meaningful
- [x] **Existing tests preserved**: \`move throws when target already exists\` still passes (EEXIST rethrown as the same string)
- [x] \`move_note rejects when target exists without force\` renamed to \`move_note rejects when target already exists\`

## Out of scope

- **#39** (inline wiki-link updates on move) — separate issue, deliberately not touched
- **List-walk performance in \`updateRelatedRefs\`** — separate audit improvement
- **Atomic write in \`upsert\`** (#48) — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)