### PR TITLE
fix(search): cluster of SearchIndex bug fixes and polish

### DIFF
--- a/server/src/search/SearchIndex.ts
+++ b/server/src/search/SearchIndex.ts
@@ -71,6 +71,7 @@ export class SearchIndex {
     if (queryTerms.length === 0) return [];
 
     const results: SearchResult[] = [];
+    const safeAvgDocLen = this.avgDocLen > 0 ? this.avgDocLen : 1;
 
     // Precompute IDF per query term to avoid redundant O(entries) scans
     const idfMap = new Map<string, number>();
@@ -88,7 +89,7 @@ export class SearchIndex {
         const idf = idfMap.get(term)!;
         const tfNorm =
           (tf * (BM25_K1 + 1)) /
-          (tf + BM25_K1 * (1 - BM25_B + BM25_B * (entry.docLen / this.avgDocLen)));
+          (tf + BM25_K1 * (1 - BM25_B + BM25_B * (entry.docLen / safeAvgDocLen)));
         score += idf * tfNorm;
       }
       if (score > 0) {

--- a/server/src/search/SearchIndex.ts
+++ b/server/src/search/SearchIndex.ts
@@ -15,7 +15,7 @@ interface IndexEntry {
   frontmatter: NoteListItem['frontmatter'];
   terms: Map<string, number>; // term -> weighted frequency
   docLen: number; // total weighted term count
-  text: string; // for excerpts
+  text: string; // for excerpts — excludes related slugs
 }
 
 export class SearchIndex {
@@ -36,7 +36,6 @@ export class SearchIndex {
       const text = [
         note.frontmatter.title,
         ...note.frontmatter.tags,
-        ...note.frontmatter.related,
       ].join(' ');
 
       return { slug: note.slug, frontmatter: note.frontmatter, terms, docLen, text };
@@ -57,7 +56,6 @@ export class SearchIndex {
       const text = [
         note.frontmatter.title,
         ...note.frontmatter.tags,
-        ...note.frontmatter.related,
         note.content,
       ].join(' ');
 

--- a/server/src/search/SearchIndex.ts
+++ b/server/src/search/SearchIndex.ts
@@ -127,7 +127,7 @@ export class SearchIndex {
   }
 
   private addWeightedTerms(terms: Map<string, number>, text: string, weight: number): number {
-    const words = text.toLowerCase().split(/\W+/).filter((w) => w.length > 1);
+    const words = text.toLowerCase().split(/\W+/).filter((w) => w.length >= 1);
     for (const word of words) {
       terms.set(word, (terms.get(word) || 0) + weight);
     }
@@ -152,7 +152,7 @@ export class SearchIndex {
     return query
       .toLowerCase()
       .split(/\W+/)
-      .filter((w) => w.length > 1);
+      .filter((w) => w.length >= 1);
   }
 
   private makeExcerpt(text: string, terms: string[]): string {

--- a/server/src/search/SearchIndex.ts
+++ b/server/src/search/SearchIndex.ts
@@ -10,6 +10,10 @@ const FIELD_WEIGHTS = {
   body: 1.0,
 } as const;
 
+const EXCERPT_PRE_CHARS = 40;
+const EXCERPT_POST_CHARS = 80;
+const EXCERPT_FALLBACK_LEN = 120;
+
 interface IndexEntry {
   slug: string;
   frontmatter: NoteListItem['frontmatter'];
@@ -160,11 +164,11 @@ export class SearchIndex {
     for (const term of terms) {
       const idx = lower.indexOf(term);
       if (idx >= 0) {
-        const start = Math.max(0, idx - 40);
-        const end = Math.min(text.length, idx + 80);
+        const start = Math.max(0, idx - EXCERPT_PRE_CHARS);
+        const end = Math.min(text.length, idx + EXCERPT_POST_CHARS);
         return (start > 0 ? '...' : '') + text.slice(start, end) + (end < text.length ? '...' : '');
       }
     }
-    return text.slice(0, 120);
+    return text.slice(0, EXCERPT_FALLBACK_LEN);
   }
 }

--- a/server/src/search/__tests__/SearchIndex.test.ts
+++ b/server/src/search/__tests__/SearchIndex.test.ts
@@ -250,6 +250,26 @@ describe('SearchIndex', () => {
     expect(results[0].slug).toBe('projects/finances/overview');
   });
 
+  test('issue #46: excerpt does not center on a related-slug match', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'overview',
+        frontmatter: {
+          title: 'Finances Overview',
+          date: '2026-01-01',
+          tags: [],
+          related: ['react-hooks-deep-dive'],
+        },
+        content: 'A long body of meaningful prose about finances and budgeting.',
+      },
+    ]);
+    const results = index.search('hooks');
+    expect(results).toHaveLength(1);
+    // Excerpt must come from human-readable text (title or body),
+    // not the related slug `react-hooks-deep-dive`.
+    expect(results[0].excerpt).not.toMatch(/react-hooks-deep-dive/);
+  });
+
   test('issue #43: search does not return NaN-suppressed empty when avgDocLen is 0', () => {
     // All-empty corpus: notes exist but every field is empty after tokenization.
     // Without the guard, avgDocLen = 0 → docLen/avgDocLen = NaN → score NaN → filtered to [].

--- a/server/src/search/__tests__/SearchIndex.test.ts
+++ b/server/src/search/__tests__/SearchIndex.test.ts
@@ -304,24 +304,23 @@ describe('SearchIndex', () => {
     expect(results[0].excerpt).not.toMatch(/react-hooks-deep-dive/);
   });
 
-  test('issue #43: search does not return NaN-suppressed empty when avgDocLen is 0', () => {
-    // All-empty corpus: notes exist but every field is empty after tokenization.
-    // Without the guard, avgDocLen = 0 → docLen/avgDocLen = NaN → score NaN → filtered to [].
+  test('issue #43: search on empty-content corpus does not throw or leak NaN scores', () => {
+    // Single note with all-empty fields → docLen = 0 and avgDocLen = 0.
+    // The safeAvgDocLen guard prevents x/0 NaN if the inner loop ever reached
+    // the BM25 length-normalization line. With current control flow tf === 0
+    // short-circuits earlier, but we lock in the defensive contract anyway.
     index.buildIndexWithContent([
       {
-        slug: 'a',
+        slug: 'empty',
         frontmatter: { title: '', date: '2026-01-01', tags: [], related: [] },
         content: '',
       },
     ]);
-    // We don't assert a match (there are no terms), but search should not throw or
-    // produce NaN scores under the hood. A query with no matching terms returns [].
+    expect(() => index.search('anything')).not.toThrow();
     expect(index.search('anything')).toEqual([]);
+  });
 
-    // Now mix in a real note via direct injection of an entry with empty content
-    // alongside a note whose only term is in the title — the all-empty entry
-    // would historically poison avgDocLen across the corpus calculation but more
-    // importantly make scoring NaN if it were the sole match path.
+  test('issue #43: search on mixed empty + real notes returns finite scores', () => {
     index.buildIndexWithContent([
       {
         slug: 'empty',

--- a/server/src/search/__tests__/SearchIndex.test.ts
+++ b/server/src/search/__tests__/SearchIndex.test.ts
@@ -249,4 +249,40 @@ describe('SearchIndex', () => {
     expect(results).toHaveLength(1);
     expect(results[0].slug).toBe('projects/finances/overview');
   });
+
+  test('issue #43: search does not return NaN-suppressed empty when avgDocLen is 0', () => {
+    // All-empty corpus: notes exist but every field is empty after tokenization.
+    // Without the guard, avgDocLen = 0 → docLen/avgDocLen = NaN → score NaN → filtered to [].
+    index.buildIndexWithContent([
+      {
+        slug: 'a',
+        frontmatter: { title: '', date: '2026-01-01', tags: [], related: [] },
+        content: '',
+      },
+    ]);
+    // We don't assert a match (there are no terms), but search should not throw or
+    // produce NaN scores under the hood. A query with no matching terms returns [].
+    expect(index.search('anything')).toEqual([]);
+
+    // Now mix in a real note via direct injection of an entry with empty content
+    // alongside a note whose only term is in the title — the all-empty entry
+    // would historically poison avgDocLen across the corpus calculation but more
+    // importantly make scoring NaN if it were the sole match path.
+    index.buildIndexWithContent([
+      {
+        slug: 'empty',
+        frontmatter: { title: '', date: '2026-01-01', tags: [], related: [] },
+        content: '',
+      },
+      {
+        slug: 'real',
+        frontmatter: { title: 'Kubernetes', date: '2026-01-01', tags: [], related: [] },
+        content: '',
+      },
+    ]);
+    const results = index.search('kubernetes');
+    expect(results).toHaveLength(1);
+    expect(results[0].slug).toBe('real');
+    expect(Number.isFinite(results[0].score)).toBe(true);
+  });
 });

--- a/server/src/search/__tests__/SearchIndex.test.ts
+++ b/server/src/search/__tests__/SearchIndex.test.ts
@@ -250,6 +250,40 @@ describe('SearchIndex', () => {
     expect(results[0].slug).toBe('projects/finances/overview');
   });
 
+  test('issue #54: single-character search query "C" matches notes mentioning C', () => {
+    index.buildIndexWithContent([
+      {
+        slug: 'c-lang',
+        frontmatter: { title: 'The C Programming Language', date: '2026-01-01', tags: ['c'], related: [] },
+        content: 'Notes on C.',
+      },
+      {
+        slug: 'rust-lang',
+        frontmatter: { title: 'Rust Programming Language', date: '2026-01-01', tags: ['rust'], related: [] },
+        content: 'Notes on Rust.',
+      },
+    ]);
+    const results = index.search('C');
+    expect(results.length).toBeGreaterThanOrEqual(1);
+    expect(results[0].slug).toBe('c-lang');
+  });
+
+  test('issue #54: single-character query does not trigger prefix matching', () => {
+    // Without the length-3 prefix gate, "c" would match "computer", "code", etc.
+    // We keep the gate (prefix-match requires >= 3 chars), so single-char queries
+    // are exact-only.
+    index.buildIndexWithContent([
+      {
+        slug: 'a',
+        frontmatter: { title: 'Computer Programming', date: '2026-01-01', tags: [], related: [] },
+        content: 'About computers.',
+      },
+    ]);
+    // No exact "c" token in the indexed text, so result is empty.
+    const results = index.search('c');
+    expect(results).toHaveLength(0);
+  });
+
   test('issue #46: excerpt does not center on a related-slug match', () => {
     index.buildIndexWithContent([
       {


### PR DESCRIPTION
## Summary

Bundles four small, related changes to `SearchIndex.ts` so they ship together rather than as separate PRs.

- **fix #43** — guard BM25 length normalization against `avgDocLen=0` to prevent NaN scores. Defensive: through the public API the inner loop's `tf === 0` short-circuit usually beats the division to it, but the contract is now explicit.
- **fix #46** — exclude related slugs from the excerpt source. Scoring corpus is unchanged (related slugs still contribute to relevance via `addWeightedTerms`), only the human-readable `text` used by `makeExcerpt` is trimmed.
- **feat #54** — single-character search queries (`C`, `R`) now match. The `length > 1` token filter relaxed to `>= 1` in both `tokenizeQuery` and `addWeightedTerms`. Prefix-match gates (`< 3`) in `getTermFrequency`/`getDocFrequency` are intentionally untouched, so single-char queries remain exact-only and won't bleed into broad prefix matches.
- **part of #55** — extract magic numbers `40`/`80`/`120` in `makeExcerpt` to named constants.

## Test plan

- [x] `npm test --prefix server` — 154/154 passing (149 before, +5 new tests across #43, #46, #54)
- [x] Issue #46 regression test asserts excerpt does not center on a related-slug match
- [x] Issue #54 includes both a positive case (single-char `C` matches) and a negative case (single-char does not trigger prefix matching)
- [x] Issue #43 defensive smoke tests cover empty-corpus and mixed-corpus paths
- [x] Existing prefix-matching tests (length-3 gate, exact-match) all still pass
- [x] No public-API changes; `IndexEntry.text` semantics narrowed (now excerpt-only)

Closes #43, #46, #54. Partial #55 (named excerpt constants done; `notesDir` resolve still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)