### PR TITLE
fix(NoteStore): cluster of cleanup fixes (date validation, symlinks, dedup)

### DIFF
--- a/server/src/notes/NoteStore.ts
+++ b/server/src/notes/NoteStore.ts
@@ -120,31 +120,15 @@ export class NoteStore extends EventEmitter {
   }
 
   async list(): Promise<NoteListItem[]> {
-    const mdFiles = await this.walkMdFiles(this.notesDir);
-    const notes = await Promise.all(
-      mdFiles.map(async (filePath) => {
-        const rel = path.relative(this.notesDir, filePath);
-        const slug = rel.replace(/\.md$/, '');
-        try {
-          const raw = await fs.readFile(filePath, 'utf-8');
-          const parsed = matter(raw);
-          return {
-            slug,
-            frontmatter: this.parseFrontmatter(parsed.data),
-          } as NoteListItem;
-        } catch (e) {
-          console.error(`[library] Skipping unreadable note "${slug}":`, e instanceof Error ? e.message : e);
-          return null;
-        }
-      })
-    );
-
-    return notes
-      .filter((n): n is NoteListItem => n !== null)
-      .sort((a, b) => b.frontmatter.date.localeCompare(a.frontmatter.date));
+    const all = await this.readAllNotes();
+    return all.map(({ slug, frontmatter }) => ({ slug, frontmatter }));
   }
 
   async listWithContent(): Promise<Array<NoteListItem & { content: string }>> {
+    return this.readAllNotes();
+  }
+
+  private async readAllNotes(): Promise<Array<NoteListItem & { content: string }>> {
     const mdFiles = await this.walkMdFiles(this.notesDir);
     const notes = await Promise.all(
       mdFiles.map(async (filePath) => {

--- a/server/src/notes/NoteStore.ts
+++ b/server/src/notes/NoteStore.ts
@@ -420,9 +420,23 @@ export class NoteStore extends EventEmitter {
   }
 
   private parseFrontmatter(data: Record<string, unknown>): NoteFrontmatter {
+    // gray-matter parses YAML date scalars (e.g. `date: 2020-01-01`) as JS
+    // Date objects. Extract the UTC calendar date in that case, which preserves
+    // the author's intent regardless of local timezone. Plain strings (e.g.
+    // from notes created by this app) stay as-is. Anything else (missing,
+    // malformed non-ISO string) falls back to today.
+    let date: string;
+    if (data.date instanceof Date) {
+      date = data.date.toISOString().split('T')[0];
+    } else {
+      const rawDate = String(data.date ?? '');
+      date = /^\d{4}-\d{2}-\d{2}$/.test(rawDate)
+        ? rawDate
+        : new Date().toISOString().split('T')[0];
+    }
     return {
       title: String(data.title || 'Untitled'),
-      date: String(data.date || new Date().toISOString().split('T')[0]),
+      date,
       tags: Array.isArray(data.tags) ? data.tags.map(String) : [],
       related: Array.isArray(data.related) ? data.related.map(String) : [],
     };

--- a/server/src/notes/NoteStore.ts
+++ b/server/src/notes/NoteStore.ts
@@ -170,7 +170,12 @@ export class NoteStore extends EventEmitter {
       .sort((a, b) => b.frontmatter.date.localeCompare(a.frontmatter.date));
   }
 
-  private async walkMdFiles(dir: string): Promise<string[]> {
+  private async walkMdFiles(dir: string, visited?: Set<string>): Promise<string[]> {
+    const seen = visited ?? new Set<string>();
+    const realDir = await fs.realpath(dir).catch(() => dir);
+    if (seen.has(realDir)) return [];
+    seen.add(realDir);
+
     const results: string[] = [];
     let entries: import('fs').Dirent[];
     try {
@@ -180,9 +185,18 @@ export class NoteStore extends EventEmitter {
     }
     for (const entry of entries) {
       const fullPath = path.join(dir, entry.name);
-      if (entry.isDirectory()) {
-        results.push(...(await this.walkMdFiles(fullPath)));
-      } else if (entry.isFile() && entry.name.endsWith('.md') && !fullPath.includes('.sync-conflict')) {
+      let isDir = entry.isDirectory();
+      let isFile = entry.isFile();
+      if (entry.isSymbolicLink()) {
+        // Resolve the link target. stat() follows symlinks; lstat() does not.
+        const stat = await fs.stat(fullPath).catch(() => null);
+        if (!stat) continue;
+        isDir = stat.isDirectory();
+        isFile = stat.isFile();
+      }
+      if (isDir) {
+        results.push(...(await this.walkMdFiles(fullPath, seen)));
+      } else if (isFile && entry.name.endsWith('.md') && !fullPath.includes('.sync-conflict')) {
         results.push(fullPath);
       }
     }

--- a/server/src/notes/__tests__/NoteStore.test.ts
+++ b/server/src/notes/__tests__/NoteStore.test.ts
@@ -216,6 +216,44 @@ describe('NoteStore', () => {
     expect(byContent.map((n) => n.slug)).toEqual(byList.map((n) => n.slug));
   });
 
+  test('issue #45: list includes notes inside symlinked subdirectories', async () => {
+    // Outer note inside the vault.
+    await store.upsert({ title: 'Outer', content: 'outer body' });
+
+    // Create an external directory with a note, then symlink it into the vault.
+    const external = await fs.mkdtemp(path.join(os.tmpdir(), 'library-external-'));
+    await fs.writeFile(
+      path.join(external, 'shared.md'),
+      '---\ntitle: Shared\ndate: 2026-05-01\n---\nshared body'
+    );
+    await fs.symlink(external, path.join(dir, 'linked'));
+
+    try {
+      const notes = await store.list();
+      const slugs = notes.map((n) => n.slug);
+      expect(slugs).toContain('outer');
+      expect(slugs).toContain('linked/shared');
+    } finally {
+      await fs.rm(external, { recursive: true, force: true });
+    }
+  });
+
+  test('issue #45: walkMdFiles tolerates symlink loops without infinite recursion', async () => {
+    // a/ contains a symlink "loop" pointing back to a/, plus a real note.
+    const aDir = path.join(dir, 'a');
+    await fs.mkdir(aDir);
+    await fs.writeFile(
+      path.join(aDir, 'real.md'),
+      '---\ntitle: Real\ndate: 2026-05-01\n---\nreal body'
+    );
+    await fs.symlink(aDir, path.join(aDir, 'loop'));
+
+    // Should complete (not hang) and include the real note exactly once.
+    const notes = await store.list();
+    const realCount = notes.filter((n) => n.slug === 'a/real').length;
+    expect(realCount).toBe(1);
+  });
+
   test('list() handles unreadable subdirectory gracefully', async () => {
     await store.upsert({ title: 'Root Note', content: 'OK.' });
     const subdir = path.join(dir, 'locked-folder');

--- a/server/src/notes/__tests__/NoteStore.test.ts
+++ b/server/src/notes/__tests__/NoteStore.test.ts
@@ -90,6 +90,33 @@ describe('NoteStore', () => {
     expect(deleted).toBe(false);
   });
 
+  test('issue #47: non-ISO date in frontmatter falls back to today, preserving sort order', async () => {
+    // Note A: explicit valid ISO date in 2020 — should sort last (oldest).
+    await fs.writeFile(
+      path.join(dir, 'old-note.md'),
+      '---\ntitle: Old Note\ndate: 2020-01-01\n---\nBody.'
+    );
+    // Note B: malformed date "January 2025" — should fall back to today,
+    // sorting at the top alongside any other today-dated notes.
+    await fs.writeFile(
+      path.join(dir, 'bad-date.md'),
+      '---\ntitle: Bad Date\ndate: January 2025\n---\nBody.'
+    );
+
+    const today = new Date().toISOString().split('T')[0];
+    const notes = await store.list();
+    const bad = notes.find((n) => n.slug === 'bad-date');
+    const old = notes.find((n) => n.slug === 'old-note');
+    expect(bad).toBeDefined();
+    expect(old).toBeDefined();
+    expect(bad!.frontmatter.date).toBe(today);
+    expect(old!.frontmatter.date).toBe('2020-01-01');
+    // Sort: bad-date (today) before old-note (2020).
+    const badIdx = notes.findIndex((n) => n.slug === 'bad-date');
+    const oldIdx = notes.findIndex((n) => n.slug === 'old-note');
+    expect(badIdx).toBeLessThan(oldIdx);
+  });
+
   test('list sorts by date descending', async () => {
     await store.upsert({ title: 'Alpha', content: 'a' });
     await store.upsert({ title: 'Beta', content: 'b' });


### PR DESCRIPTION
## Summary

Bundles three small NoteStore changes that all touch the same file and share the same review surface.

- **fix #47** — `parseFrontmatter` now validates that the frontmatter `date` is either a YAML-parsed `Date` object (gray-matter does this for unquoted `date: 2020-01-01` scalars) or a `YYYY-MM-DD` string. Anything else (`"January 2025"`, malformed strings) falls back to today's date so list-sort order via `localeCompare` stays consistent. The implementer caught the YAML-`Date`-object case while writing the test — the plan only handled strings.
- **fix #45** — `walkMdFiles` now follows symlinked directories using `fs.stat` (resolves the link) instead of relying on `Dirent.isDirectory()` (which returns `false` for symlinks). Loop protection via a `Set<string>` of `fs.realpath`-resolved canonical paths. Notes inside symlinked subfolders (cross-vault references, shared project folders) are now visible to `list()` / `listWithContent()` / search.
- **refactor #49** — `list()` and `listWithContent()` now delegate to a private `readAllNotes()` helper. Disk read cost is unchanged (both already read full file contents), and a single source of truth for walk + parse + filter + sort.

## Closes other issues

**#55 is now fully resolved** by prior work and can be closed:
- Constructor `path.resolve(notesDir)` is already in place at `NoteStore.ts:21`.
- Named excerpt constants shipped in PR #60.

## Test plan

- [x] `npm test --prefix server` — 157/157 passing (154 before, +3 new tests)
- [x] #47 regression test asserts a non-ISO date falls back to today and sort order is preserved
- [x] #45 includes a positive test (symlinked subdirectory contents are visible) and a loop-protection test (self-referential symlink does not cause infinite recursion)
- [x] #49 is a pure refactor — relies on the existing list/listWithContent test coverage
- [x] Combined spec + quality review approved with no issues above 80% confidence

Closes #45, #47, #49, #55.

🤖 Generated with [Claude Code](https://claude.com/claude-code)