### PR TITLE
refactor(mcp): centralize tool error responses and bound search_notes.limit

### DIFF
--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -736,3 +736,57 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
     });
   });
 });
+
+describe('withToolError helper (issue #50)', () => {
+  // Helper is not exported; verify behavior end-to-end via a tool that uses it.
+  // We test the observable contract: errors thrown inside a wrapped handler
+  // surface as { isError: true, content: [{ type: 'text', text: "<prefix>: <message>" }] }
+  // rather than propagating to the transport.
+
+  let dir: string;
+  let noteStore: NoteStore;
+  let searchIndex: SearchIndex;
+
+  beforeEach(async () => {
+    dir = await fs.mkdtemp(path.join(os.tmpdir(), 'library-mcp-test-'));
+    noteStore = new NoteStore(dir);
+    searchIndex = new SearchIndex();
+    await noteStore.initialize();
+  });
+
+  afterEach(async () => {
+    await noteStore.close();
+    await fs.rm(dir, { recursive: true, force: true });
+  });
+
+  test('list_notes returns isError response when noteStore.list throws', async () => {
+    // Force list() to throw by closing the store's underlying directory then
+    // making the directory unreadable. Simpler: mock list() via prototype override.
+    const originalList = noteStore.list.bind(noteStore);
+    noteStore.list = async () => { throw new Error('synthetic failure'); };
+    try {
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const tools = (server as unknown as { _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<{ isError?: boolean; content: { type: string; text: string }[] }> }> })._registeredTools;
+      const result = await tools['list_notes'].handler({}, {});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Failed to list notes');
+      expect(result.content[0].text).toContain('synthetic failure');
+    } finally {
+      noteStore.list = originalList;
+    }
+  });
+
+  test('search_notes returns isError response when search throws', async () => {
+    const originalSearch = searchIndex.search.bind(searchIndex);
+    searchIndex.search = () => { throw new Error('boom'); };
+    try {
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const tools = (server as unknown as { _registeredTools: Record<string, { handler: (args: unknown, extra: unknown) => Promise<{ isError?: boolean; content: { type: string; text: string }[] }> }> })._registeredTools;
+      const result = await tools['search_notes'].handler({ query: 'x', limit: 10 }, {});
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('boom');
+    } finally {
+      searchIndex.search = originalSearch;
+    }
+  });
+});

--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -505,6 +505,62 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
     });
   });
 
+  describe('search_notes limit validation (issue #53)', () => {
+    type ToolEntry = {
+      inputSchema: z.ZodType;
+      handler: (args: unknown, extra: unknown) => Promise<unknown>;
+    };
+
+    function getTool(server: ReturnType<typeof createMcpServer>, name: string): ToolEntry {
+      const tools = (server as unknown as { _registeredTools: Record<string, ToolEntry> })._registeredTools;
+      const entry = tools[name];
+      if (!entry) throw new Error(`Tool "${name}" not registered`);
+      return entry;
+    }
+
+    test('limit: 0 fails Zod validation', () => {
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const { inputSchema } = getTool(server, 'search_notes');
+      const parsed = inputSchema.safeParse({ query: 'x', limit: 0 });
+      expect(parsed.success).toBe(false);
+    });
+
+    test('limit: -1 fails Zod validation', () => {
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const { inputSchema } = getTool(server, 'search_notes');
+      const parsed = inputSchema.safeParse({ query: 'x', limit: -1 });
+      expect(parsed.success).toBe(false);
+    });
+
+    test('limit: 999999 fails Zod validation', () => {
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const { inputSchema } = getTool(server, 'search_notes');
+      const parsed = inputSchema.safeParse({ query: 'x', limit: 999999 });
+      expect(parsed.success).toBe(false);
+    });
+
+    test('limit: 1.5 (non-integer) fails Zod validation', () => {
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const { inputSchema } = getTool(server, 'search_notes');
+      const parsed = inputSchema.safeParse({ query: 'x', limit: 1.5 });
+      expect(parsed.success).toBe(false);
+    });
+
+    test('limit: 50 (in range) passes', () => {
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const { inputSchema } = getTool(server, 'search_notes');
+      const parsed = inputSchema.safeParse({ query: 'x', limit: 50 });
+      expect(parsed.success).toBe(true);
+    });
+
+    test('limit: omitted (undefined) passes — falls back to default', () => {
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const { inputSchema } = getTool(server, 'search_notes');
+      const parsed = inputSchema.safeParse({ query: 'x' });
+      expect(parsed.success).toBe(true);
+    });
+  });
+
   describe('coerceStringArray', () => {
     test('passes through an existing array unchanged', () => {
       expect(coerceStringArray(['tag1', 'tag2'])).toEqual(['tag1', 'tag2']);

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -227,7 +227,7 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
     'Search the knowledge base using keyword search. Returns matching notes scored by relevance, with excerpts.',
     {
       query: z.string().describe('Search query — keywords to search for'),
-      limit: z.number().optional().describe('Maximum number of results to return (default: 10)'),
+      limit: z.number().int().min(1).max(100).optional().describe('Maximum number of results to return (default: 10, max: 100)'),
     },
     async ({ query, limit }) => {
       let results;

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -40,6 +40,20 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
     version: '1.0.0',
   });
 
+  type ToolResponse = {
+    content: Array<{ type: 'text'; text: string }>;
+    isError?: boolean;
+  };
+
+  async function withToolError(prefix: string, fn: () => Promise<ToolResponse>): Promise<ToolResponse> {
+    try {
+      return await fn();
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      return { isError: true, content: [{ type: 'text', text: `${prefix}: ${msg}` }] };
+    }
+  }
+
   // ── Tools ──────────────────────────────────────────────────────────────────
 
   server.tool(
@@ -49,18 +63,11 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
     'and how to navigate it effectively. ' +
     'Load this silently for context; do not summarize or recite its contents unless the user explicitly asks.',
     {},
-    async () => {
-      try {
+    async () =>
+      withToolError('Failed to load vault context', async () => {
         const result = await vaultContextHandler(notesDir);
         return { content: [{ type: 'text', text: result.contents[0].text }] };
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return {
-          isError: true,
-          content: [{ type: 'text', text: msg }],
-        };
-      }
-    }
+      })
   );
 
   server.tool(
@@ -69,20 +76,13 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
     {
       path: z.string().optional().describe('Optional slug prefix to filter by (e.g. "projects/startup"). Trailing slash is normalized automatically.'),
     },
-    async ({ path: prefix }) => {
-      let notes;
-      try {
-        notes = await noteStore.list();
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return { isError: true, content: [{ type: 'text', text: `Failed to list notes: ${msg}` }] };
-      }
-      const normalized = prefix && (prefix.endsWith('/') ? prefix : prefix + '/');
-      const filtered = normalized ? notes.filter((n) => n.slug.startsWith(normalized)) : notes;
-      return {
-        content: [{ type: 'text', text: JSON.stringify(filtered, null, 2) }],
-      };
-    }
+    async ({ path: prefix }) =>
+      withToolError('Failed to list notes', async () => {
+        const notes = await noteStore.list();
+        const normalized = prefix && (prefix.endsWith('/') ? prefix : prefix + '/');
+        const filtered = normalized ? notes.filter((n) => n.slug.startsWith(normalized)) : notes;
+        return { content: [{ type: 'text', text: JSON.stringify(filtered, null, 2) }] };
+      })
   );
 
   server.tool(
@@ -91,25 +91,13 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
     { slug: z.string().describe('The note slug (e.g. "react-hooks-rules")') },
     async ({ slug }) => {
       if (!isValidSlug(slug)) return slugValidationError(slug);
-      let note;
-      try {
-        note = await noteStore.get(slug);
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return {
-          isError: true,
-          content: [{ type: 'text', text: `Failed to read note "${slug}": ${msg}` }],
-        };
-      }
-      if (!note) {
-        return {
-          content: [{ type: 'text', text: `Note "${slug}" not found.` }],
-          isError: true,
-        };
-      }
-      return {
-        content: [{ type: 'text', text: note.raw }],
-      };
+      return withToolError(`Failed to read note "${slug}"`, async () => {
+        const note = await noteStore.get(slug);
+        if (!note) {
+          return { isError: true, content: [{ type: 'text', text: `Note "${slug}" not found.` }] };
+        }
+        return { content: [{ type: 'text', text: note.raw }] };
+      });
     }
   );
 
@@ -196,29 +184,26 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
     { slug: z.string().describe('The slug of the note to delete') },
     async ({ slug }) => {
       if (!isValidSlug(slug)) return slugValidationError(slug);
-      let deleted;
-      try {
-        deleted = await noteStore.delete(slug);
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return { isError: true, content: [{ type: 'text', text: `Failed to delete note "${slug}": ${msg}` }] };
+      const result = await withToolError(`Failed to delete note "${slug}"`, async () => {
+        const deleted = await noteStore.delete(slug);
+        if (!deleted) {
+          return { isError: true, content: [{ type: 'text', text: `Note "${slug}" not found.` }] };
+        }
+        return { content: [{ type: 'text', text: `Deleted note "${slug}".` }] };
+      });
+      // Secondary best-effort: rebuild the search index after a successful delete.
+      // A failure here is logged but does not change the response — the deletion
+      // itself succeeded, and the index will catch up on the next watcher tick.
+      if (!result.isError) {
+        try {
+          const allNotes = await noteStore.listWithContent();
+          searchIndex.buildIndexWithContent(allNotes);
+        } catch (e) {
+          const msg = e instanceof Error ? e.message : String(e);
+          console.error(`[library] Failed to rebuild search index after deleting "${slug}":`, msg);
+        }
       }
-      if (!deleted) {
-        return {
-          content: [{ type: 'text', text: `Note "${slug}" not found.` }],
-          isError: true,
-        };
-      }
-      try {
-        const allNotes = await noteStore.listWithContent();
-        searchIndex.buildIndexWithContent(allNotes);
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        console.error(`[library] Failed to rebuild search index after deleting "${slug}":`, msg);
-      }
-      return {
-        content: [{ type: 'text', text: `Deleted note "${slug}".` }],
-      };
+      return result;
     }
   );
 
@@ -229,28 +214,14 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
       query: z.string().describe('Search query — keywords to search for'),
       limit: z.number().int().min(1).max(100).optional().describe('Maximum number of results to return (default: 10, max: 100)'),
     },
-    async ({ query, limit }) => {
-      let results;
-      try {
-        results = searchIndex.search(query, limit ?? 10);
-      } catch (e) {
-        const msg = e instanceof Error ? e.message : String(e);
-        return { isError: true, content: [{ type: 'text', text: `Search failed: ${msg}` }] };
-      }
-      if (results.length === 0) {
-        return {
-          content: [{ type: 'text', text: `No notes found matching "${query}".` }],
-        };
-      }
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify(results, null, 2),
-          },
-        ],
-      };
-    }
+    async ({ query, limit }) =>
+      withToolError('Search failed', async () => {
+        const results = searchIndex.search(query, limit ?? 10);
+        if (results.length === 0) {
+          return { content: [{ type: 'text', text: `No notes found matching "${query}".` }] };
+        }
+        return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
+      })
   );
 
   server.tool(


### PR DESCRIPTION
## Summary

Two small MCP-layer hardening changes that share the same review surface (`server/src/mcp/server.ts`).

- **fix #53** — `search_notes.limit` is now bounded: `z.number().int().min(1).max(100).optional()`. Previously `limit: 0` returned silently empty (Array.slice(0, 0)), `limit: -1` also empty, and large values returned the entire index. Validation errors now surface clearly to clients. Description updated to mention the cap so the LLM knows the upper bound.
- **refactor #50** — Adds a `withToolError(prefix, fn)` helper inside `createMcpServer` and applies it to the 5 simple handlers (`get_vault_context`, `list_notes`, `get_note`, `search_notes`, `delete_note`). The 3 handlers with bespoke error logic (`create_note`, `update_note`, `move_note`) keep their inline try/catch — their domain-specific translation (e.g. move_note's "already exists" guidance) doesn't reduce cleanly through a generic prefix-wrapper. The win is a single source of truth for the response shape across handlers that share it.

### Minor behavior change worth noting

`get_vault_context` previously returned the raw error message; after the wrapper it gains a `"Failed to load vault context: "` prefix. For the generic I/O path that means "Failed to load vault context: Failed to read profile.md: <msg>" — a double-prefix that's mildly redundant but consistent with the rest of the tool surface. No existing test asserts on the wrapped tool's error text (all `vaultContextHandler` tests probe the function directly).

## Test plan

- [x] `npm test --prefix server` — 165/165 passing (157 before, +8 new)
- [x] #53: 6 tests against the registered `search_notes` Zod schema — `safeParse` exercises real Zod, not mocked
- [x] #50: 2 tests verify the wrapper produces `{ isError: true, content: [...] }` when the wrapped fn throws (mock `noteStore.list` and `searchIndex.search`, restore via try/finally)
- [x] Combined spec + quality review approved with no issues above 80% confidence

Closes #50, #53.

🤖 Generated with [Claude Code](https://claude.com/claude-code)