### PR TITLE
chore(config): remove unused frontmatterTemplate field

### DIFF
--- a/server/src/config/config.ts
+++ b/server/src/config/config.ts
@@ -8,7 +8,6 @@ const CONFIG_PATH = path.join(__dirname, '../../config.json');
 
 const DEFAULT_CONFIG: Config = {
   notesDir: path.join(__dirname, '../../../notes'),
-  frontmatterTemplate: '---\ntitle: "{{title}}"\ndate: {{date}}\ntags: []\nrelated: []\n---',
 };
 
 export async function loadConfig(): Promise<Config> {

--- a/server/src/types.ts
+++ b/server/src/types.ts
@@ -26,5 +26,4 @@ export interface SearchResult {
 
 export interface Config {
   notesDir: string;
-  frontmatterTemplate: string;
 }


### PR DESCRIPTION
## Summary

The \`frontmatterTemplate\` field on the \`Config\` interface was declared and given a default value, but nothing actually read it. \`NoteStore.upsert\` calls \`matter.stringify\` directly without consulting any template. Drop it per option A from the issue ("If we ever need configurable frontmatter ordering or default fields, add it back with a real consumer").

## Test plan

- [x] \`npm test\` — 165/165 passing (no behavior change, no new tests needed)
- [x] \`tsc --noEmit\` clean — no callers depended on the field

Closes #52.

🤖 Generated with [Claude Code](https://claude.com/claude-code)