### PR TITLE
feat(mcp): list_todos tool surfaces incomplete checkboxes

### DIFF
--- a/server/src/mcp/__tests__/mcpTools.test.ts
+++ b/server/src/mcp/__tests__/mcpTools.test.ts
@@ -475,6 +475,99 @@ describe('MCP tool logic — NoteStore + SearchIndex integration', () => {
     });
   });
 
+  describe('list_todos tool', () => {
+    type ToolEntry = {
+      inputSchema: import('zod').ZodType;
+      handler: (args: unknown, extra: unknown) => Promise<{
+        isError?: boolean;
+        content: { type: string; text: string }[];
+      }>;
+    };
+
+    function getTool(server: ReturnType<typeof createMcpServer>, name: string): ToolEntry {
+      const tools = (server as unknown as { _registeredTools: Record<string, ToolEntry> })._registeredTools;
+      const entry = tools[name];
+      if (!entry) throw new Error(`Tool "${name}" not registered`);
+      return entry;
+    }
+
+    test('returns empty-result message when no notes have todos', async () => {
+      await noteStore.upsert({ title: 'Plain', content: 'No checkboxes here.' });
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const result = await getTool(server, 'list_todos').handler({}, {});
+      expect(result.content[0].text).toContain('No notes found with incomplete TODOs');
+    });
+
+    test('returns notes with their unchecked todos', async () => {
+      await noteStore.upsert({
+        title: 'Tasks',
+        content: '- [ ] First task\n- [x] Done task\n- [ ] Second task',
+      });
+      await noteStore.upsert({ title: 'Empty', content: 'no todos' });
+
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const result = await getTool(server, 'list_todos').handler({}, {});
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(1);
+      expect(parsed[0].slug).toBe('tasks');
+      expect(parsed[0].title).toBe('Tasks');
+      expect(parsed[0].todos).toEqual(['First task', 'Second task']);
+    });
+
+    test('filters by path prefix', async () => {
+      await noteStore.upsert({ slug: 'projects/alpha', title: 'Alpha', content: '- [ ] alpha task' });
+      await noteStore.upsert({ slug: 'projects/beta', title: 'Beta', content: '- [ ] beta task' });
+      await noteStore.upsert({ slug: 'inbox/gamma', title: 'Gamma', content: '- [ ] gamma task' });
+
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const result = await getTool(server, 'list_todos').handler({ path: 'projects' }, {});
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(2);
+      expect(parsed.map((p: { slug: string }) => p.slug).sort()).toEqual([
+        'projects/alpha',
+        'projects/beta',
+      ]);
+    });
+
+    test('respects limit parameter', async () => {
+      for (let i = 0; i < 5; i++) {
+        await noteStore.upsert({ title: `Note ${i}`, content: `- [ ] task ${i}` });
+      }
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const result = await getTool(server, 'list_todos').handler({ limit: 2 }, {});
+      const parsed = JSON.parse(result.content[0].text);
+      expect(parsed).toHaveLength(2);
+    });
+
+    test('limit out of bounds (0, 101, -1) fails Zod validation', () => {
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const { inputSchema } = getTool(server, 'list_todos');
+      expect(inputSchema.safeParse({ limit: 0 }).success).toBe(false);
+      expect(inputSchema.safeParse({ limit: 101 }).success).toBe(false);
+      expect(inputSchema.safeParse({ limit: -1 }).success).toBe(false);
+      expect(inputSchema.safeParse({ limit: 1.5 }).success).toBe(false);
+    });
+
+    test('omitted params are valid (use defaults)', () => {
+      const server = createMcpServer(noteStore, searchIndex, dir);
+      const { inputSchema } = getTool(server, 'list_todos');
+      expect(inputSchema.safeParse({}).success).toBe(true);
+    });
+
+    test('handler returns isError when noteStore.listWithContent throws', async () => {
+      const original = noteStore.listWithContent.bind(noteStore);
+      noteStore.listWithContent = async () => { throw new Error('boom'); };
+      try {
+        const server = createMcpServer(noteStore, searchIndex, dir);
+        const result = await getTool(server, 'list_todos').handler({}, {});
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain('boom');
+      } finally {
+        noteStore.listWithContent = original;
+      }
+    });
+  });
+
   describe('move_note', () => {
     test('move_note relocates note and updates references', async () => {
       await noteStore.upsert({ slug: 'old-slug', title: 'Moving', content: 'Body.' });

--- a/server/src/mcp/server.ts
+++ b/server/src/mcp/server.ts
@@ -5,6 +5,7 @@ import { z } from 'zod';
 import { NoteStore } from '../notes/NoteStore.js';
 import { SearchIndex } from '../search/SearchIndex.js';
 import { coerceStringArray, resolveFrontmatterParams } from './coerce.js';
+import { extractTodos } from '../notes/todos.js';
 
 export async function vaultContextHandler(notesDir: string) {
   try {
@@ -221,6 +222,37 @@ export function createMcpServer(noteStore: NoteStore, searchIndex: SearchIndex, 
           return { content: [{ type: 'text', text: `No notes found matching "${query}".` }] };
         }
         return { content: [{ type: 'text', text: JSON.stringify(results, null, 2) }] };
+      })
+  );
+
+  server.tool(
+    'list_todos',
+    'List notes that contain incomplete `- [ ]` markdown checkboxes, with each todo\'s text excerpted. ' +
+    'Filter by slug prefix to scope to a folder. ' +
+    'Useful for finding open work across the vault. Note: checkbox syntax inside fenced code blocks is ignored.',
+    {
+      path: z.string().optional().describe('Optional slug prefix to filter by (e.g. "projects/startup"). Trailing slash is normalized automatically.'),
+      limit: z.number().int().min(1).max(100).optional().describe('Maximum number of notes to return (default: 10, max: 100)'),
+    },
+    async ({ path: prefix, limit }) =>
+      withToolError('Failed to list todos', async () => {
+        const notes = await noteStore.listWithContent();
+        const normalized = prefix && (prefix.endsWith('/') ? prefix : prefix + '/');
+        const scoped = normalized ? notes.filter((n) => n.slug.startsWith(normalized)) : notes;
+
+        const withTodos = scoped
+          .map((n) => ({
+            slug: n.slug,
+            title: n.frontmatter.title,
+            todos: extractTodos(n.content),
+          }))
+          .filter((n) => n.todos.length > 0)
+          .slice(0, limit ?? 10);
+
+        if (withTodos.length === 0) {
+          return { content: [{ type: 'text', text: 'No notes found with incomplete TODOs.' }] };
+        }
+        return { content: [{ type: 'text', text: JSON.stringify(withTodos, null, 2) }] };
       })
   );
 

--- a/server/src/notes/__tests__/todos.test.ts
+++ b/server/src/notes/__tests__/todos.test.ts
@@ -1,0 +1,84 @@
+import { extractTodos } from '../todos.js';
+
+describe('extractTodos', () => {
+  test('returns empty array for content without todos', () => {
+    expect(extractTodos('Just plain text.')).toEqual([]);
+    expect(extractTodos('')).toEqual([]);
+  });
+
+  test('extracts a single unchecked todo', () => {
+    const content = '- [ ] Buy milk';
+    expect(extractTodos(content)).toEqual(['Buy milk']);
+  });
+
+  test('extracts multiple unchecked todos preserving order', () => {
+    const content = '- [ ] First\n- [ ] Second\n- [ ] Third';
+    expect(extractTodos(content)).toEqual(['First', 'Second', 'Third']);
+  });
+
+  test('skips checked todos (lowercase x)', () => {
+    const content = '- [ ] Pending\n- [x] Done\n- [ ] Also pending';
+    expect(extractTodos(content)).toEqual(['Pending', 'Also pending']);
+  });
+
+  test('skips checked todos (uppercase X)', () => {
+    const content = '- [X] Done\n- [ ] Pending';
+    expect(extractTodos(content)).toEqual(['Pending']);
+  });
+
+  test('recognizes star and plus list markers', () => {
+    const content = '* [ ] star todo\n+ [ ] plus todo\n- [ ] dash todo';
+    expect(extractTodos(content)).toEqual(['star todo', 'plus todo', 'dash todo']);
+  });
+
+  test('recognizes indented (nested) todos', () => {
+    const content = '- [ ] Parent\n  - [ ] Sub-todo\n    - [ ] Deeper';
+    expect(extractTodos(content)).toEqual(['Parent', 'Sub-todo', 'Deeper']);
+  });
+
+  test('preserves inline content (links, code spans, formatting)', () => {
+    const content = '- [ ] Read [the docs](https://example.com) and run `npm test`';
+    expect(extractTodos(content)).toEqual([
+      'Read [the docs](https://example.com) and run `npm test`',
+    ]);
+  });
+
+  test('ignores checkbox syntax inside fenced code blocks', () => {
+    const content = [
+      '- [ ] Real todo',
+      '',
+      '```',
+      '- [ ] Not a real todo (inside code block)',
+      '```',
+      '',
+      '- [ ] Another real todo',
+    ].join('\n');
+    expect(extractTodos(content)).toEqual(['Real todo', 'Another real todo']);
+  });
+
+  test('ignores fenced code blocks with language tag', () => {
+    const content = [
+      '- [ ] Real',
+      '',
+      '```markdown',
+      '- [ ] Example syntax in docs',
+      '```',
+    ].join('\n');
+    expect(extractTodos(content)).toEqual(['Real']);
+  });
+
+  test('does not treat malformed checkbox as todo', () => {
+    expect(extractTodos('- [] missing space')).toEqual([]);
+    expect(extractTodos('-[ ] missing space after dash')).toEqual([]);
+    expect(extractTodos('- [  ] double space inside')).toEqual([]);
+  });
+
+  test('does not match plain bullets', () => {
+    expect(extractTodos('- normal bullet')).toEqual([]);
+    expect(extractTodos('* normal bullet')).toEqual([]);
+  });
+
+  test('trims trailing whitespace from todo text', () => {
+    expect(extractTodos('- [ ] Trailing spaces here   ')).toEqual(['Trailing spaces here']);
+  });
+});

--- a/server/src/notes/__tests__/todos.test.ts
+++ b/server/src/notes/__tests__/todos.test.ts
@@ -81,4 +81,30 @@ describe('extractTodos', () => {
   test('trims trailing whitespace from todo text', () => {
     expect(extractTodos('- [ ] Trailing spaces here   ')).toEqual(['Trailing spaces here']);
   });
+
+  test('inline triple-backticks in a todo are NOT treated as a code-block fence', () => {
+    // Without the line-anchor fix, the regex would strip "make build" from
+    // inside the todo, breaking it.
+    const content = '- [ ] Run ```make build``` and deploy';
+    expect(extractTodos(content)).toEqual(['Run ```make build``` and deploy']);
+  });
+
+  test('multiple todos with inline backticks all parse correctly', () => {
+    const content = [
+      '- [ ] First with `inline` code',
+      '- [ ] Second with ```triple``` inline',
+      '- [ ] Third normal',
+    ].join('\n');
+    expect(extractTodos(content)).toEqual([
+      'First with `inline` code',
+      'Second with ```triple``` inline',
+      'Third normal',
+    ]);
+  });
+
+  test('skips todo with all-whitespace body', () => {
+    expect(extractTodos('- [ ] ')).toEqual([]);
+    expect(extractTodos('- [ ]   ')).toEqual([]);
+    expect(extractTodos('- [ ] \t  ')).toEqual([]);
+  });
 });

--- a/server/src/notes/todos.ts
+++ b/server/src/notes/todos.ts
@@ -1,0 +1,11 @@
+const FENCED_CODE_BLOCK_RE = /```[\s\S]*?```/g;
+const TODO_LINE_RE = /^[ \t]*[-*+] \[ \] (.+?)[ \t]*$/gm;
+
+export function extractTodos(content: string): string[] {
+  const stripped = content.replace(FENCED_CODE_BLOCK_RE, '');
+  const todos: string[] = [];
+  for (const match of stripped.matchAll(TODO_LINE_RE)) {
+    todos.push(match[1]);
+  }
+  return todos;
+}

--- a/server/src/notes/todos.ts
+++ b/server/src/notes/todos.ts
@@ -1,5 +1,5 @@
-const FENCED_CODE_BLOCK_RE = /```[\s\S]*?```/g;
-const TODO_LINE_RE = /^[ \t]*[-*+] \[ \] (.+?)[ \t]*$/gm;
+const FENCED_CODE_BLOCK_RE = /^```[^\n]*\n[\s\S]*?^```[ \t]*$/gm;
+const TODO_LINE_RE = /^[ \t]*[-*+] \[ \] (\S.*?)[ \t]*$/gm;
 
 export function extractTodos(content: string): string[] {
   const stripped = content.replace(FENCED_CODE_BLOCK_RE, '');


### PR DESCRIPTION
## Summary

New MCP tool `list_todos` that closes the workflow gap where finding open todos required reading every note. Returns notes containing incomplete `- [ ]` markdown checkboxes, with each todo's text excerpted in the response.

### What ships

- **`extractTodos(content)` parser** in a new file `server/src/notes/todos.ts` — pure function, regex-based, line-by-line.
  - Strips fenced backtick code blocks (line-anchored: opening and closing fences must each be on their own line) so example checkbox syntax inside fenced blocks doesn't surface as real todos.
  - Recognizes `-`, `*`, `+` list markers with the GFM checkbox syntax `[ ]`. Strict spacing — `[x]`/`[X]`, `[]`, `-[ ]`, `[  ]` (double space) all rejected.
  - Indented (nested) todos preserved.
  - Bodies that are all-whitespace are rejected (no empty/space-only entries in output).
- **`list_todos` MCP tool** in `server/src/mcp/server.ts`:
  - Optional `path` prefix filter (matches `list_notes`'s shape).
  - Optional `limit` bounded `int 1..100` (matches `search_notes`'s shape).
  - Reuses the existing `withToolError` wrapper from PR #62.
  - Sorted by `frontmatter.date` descending (inherits from `listWithContent`).
  - Empty case returns the friendly text response `"No notes found with incomplete TODOs."`.
- **Response shape** matches the issue's example:
  ```json
  [
    { "slug": "...", "title": "...", "todos": ["..."] }
  ]
  ```

### Known limitations

- Only fenced **backtick** code blocks (` ``` `) are stripped. Tilde fences (`~~~`) and 4-space indented code blocks are not — todos inside those will still surface. Real-world false-positive rate is low; can revisit if it becomes a problem.

## Test plan

- [x] `npm test` — 188/188 passing (165 baseline, +16 parser tests, +7 tool integration tests)
- [x] Parser tests cover: empty input, single/multi todos, ordering, checked exclusion (`[x]`/`[X]`), all marker variants, nesting, inline formatting, **fenced code blocks (with regression test for inline triple-backticks)**, malformed forms (rejected), trailing whitespace trim, **all-whitespace body rejection**
- [x] Tool tests cover: empty case message, success path, `path` prefix filter, `limit` enforcement, Zod validation (0/-1/101/1.5 rejected, undefined accepted), error propagation via `withToolError`
- [x] Spec + quality review caught two regex correctness gaps before merge — both fixed in commit `02ef5af`:
  - Fenced-block regex now line-anchored (was matching inline triple-backtick spans)
  - Todo body now must start with non-whitespace (was capturing single-space bodies)

Closes #4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)